### PR TITLE
fix(go): revert bump cimg/go from 1.18.5 to 1.19.0 in /go

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/go:1.19.0
+FROM cimg/go:1.18.5
 
 USER root
 


### PR DESCRIPTION
Reverts alexfalkowski/docker#122