### PR TITLE
feat(deps): update trivy to v0.50.0

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -20,7 +20,7 @@ RUN curl -sSOL https://github.com/bufbuild/buf/releases/download/v1.30.0/buf-Lin
   chmod +x buf
 
 # Install trivy.
-RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.49.1
+RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.50.0
 
 # Install mkcert.
 RUN curl -sJLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64" && \

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -20,7 +20,7 @@ RUN curl -sSOL https://github.com/bufbuild/buf/releases/download/v1.30.0/buf-Lin
   chmod +x buf
 
 # Install trivy.
-RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.49.1
+RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.50.0
 
 # Install mkcert.
 RUN curl -sJLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64" && \


### PR DESCRIPTION
https://github.com/aquasecurity/trivy/releases/tag/v0.50.0