### PR TITLE
fix(go): update gsa to v1.7.5

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -41,5 +41,5 @@ RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0 && \
   go install golang.org/x/vuln/cmd/govulncheck@v1.1.3 && \
   go install gotest.tools/gotestsum@v1.12.0 && \
   go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@v0.26.0 && \
-  go install github.com/Zxilly/go-size-analyzer/cmd/gsa@v1.7.4 \
+  go install github.com/Zxilly/go-size-analyzer/cmd/gsa@v1.7.5 \
   && go clean --cache -testcache -fuzzcache -modcache && rm -rf "${GOPATH}/pkg"


### PR DESCRIPTION
https://github.com/Zxilly/go-size-analyzer/releases/tag/v1.7.5
