### PR TITLE
feat(trivy): update trivy to v0.60.0

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -sSOL https://github.com/bufbuild/buf/releases/download/v1.50.0/buf-Lin
   && chmod +x buf
 
 # Install trivy.
-RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.59.1
+RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.60.0
 
 # Install mkcert.
 RUN curl -sJLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64" \

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=go
-VERSION:=1.22
+VERSION:=1.23
 
 include ../scripts/include.mk

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -sSOL https://github.com/bufbuild/buf/releases/download/v1.50.0/buf-Lin
   && chmod +x buf
 
 # Install trivy.
-RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.59.1
+RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.60.0
 
 # Install mkcert.
 RUN curl -sJLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64" \

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=ruby
-VERSION:=1.15
+VERSION:=1.16
 
 include ../scripts/include.mk


### PR DESCRIPTION
https://github.com/aquasecurity/trivy/releases/tag/v0.60.0
