### PR TITLE
feat(k8s): update doctl to v1.126.0

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -55,5 +55,5 @@ RUN go install github.com/alexfalkowski/gocovmerge@v1.7.0 \
   && go install gotest.tools/gotestsum@v1.12.1 \
   && go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@v0.32.0 \
   && go install github.com/boyter/scc/v3@latest \
-  && go install github.com/Zxilly/go-size-analyzer/cmd/gsa@v1.8.1 \
+  && go install github.com/Zxilly/go-size-analyzer/cmd/gsa@v1.9.0 \
   && go clean --cache -testcache -fuzzcache -modcache && rm -rf "${GOPATH}/pkg"

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=go
-VERSION:=2.18
+VERSION:=2.19
 
 include ../scripts/include.mk

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -22,7 +22,7 @@ RUN curl -sSOL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz \
   && rm helm-${HELM_VERSION}-linux-amd64.tar.gz
 
 # Install doctl.
-ARG DOCTL_VERSION=1.125.1
+ARG DOCTL_VERSION=1.126.0
 RUN curl -sSOL https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz \
   && tar C . -xf doctl-${DOCTL_VERSION}-linux-amd64.tar.gz \
   && rm doctl-${DOCTL_VERSION}-linux-amd64.tar.gz

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=k8s
-VERSION:=1.50
+VERSION:=1.51
 
 include ../scripts/include.mk


### PR DESCRIPTION
https://github.com/digitalocean/doctl/releases/tag/v1.126.0
