### PR TITLE
feat(k8s): update doctl to v1.138.0

### DIFF
--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -22,7 +22,7 @@ RUN export machine="$(dpkg --print-architecture)"; curl -sSOL https://get.helm.s
   && rm helm-${HELM_VERSION}-linux-$machine.tar.gz
 
 # Install doctl.
-ARG DOCTL_VERSION=1.135.0
+ARG DOCTL_VERSION=1.138.0
 RUN export machine="$(dpkg --print-architecture)"; curl -sSOL https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-$machine.tar.gz \
   && tar C . -xf doctl-${DOCTL_VERSION}-linux-$machine.tar.gz \
   && rm doctl-${DOCTL_VERSION}-linux-$machine.tar.gz

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=k8s
-VERSION:=1.86
+VERSION:=1.87
 
 include ../make/docker.mk


### PR DESCRIPTION
https://github.com/digitalocean/doctl/releases/tag/v1.138.0
