### PR TITLE
feat(go): update gocovmerge to v2.12.0

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -53,7 +53,7 @@ WORKDIR /home/circleci/
 RUN echo "$GO_LINT_VERSION" > .go-lint-version
 
 # Install go tools.
-RUN go install github.com/alexfalkowski/gocovmerge/v2@v2.9.0 \
+RUN go install github.com/alexfalkowski/gocovmerge/v2@v2.12.0 \
   && go install golang.org/x/vuln/cmd/govulncheck@v1.1.4 \
   && go install gotest.tools/gotestsum@v1.12.3 \
   && go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@v0.34.0 \

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=go
-VERSION:=2.49
+VERSION:=2.50
 
 include ../make/docker.mk


### PR DESCRIPTION
https://github.com/alexfalkowski/gocovmerge/releases/tag/v2.12.0
