### PR TITLE
feat(root): update go to v1.26 and ruby to v4.0.1

### DIFF
--- a/root/Dockerfile
+++ b/root/Dockerfile
@@ -12,16 +12,16 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 # Install go
 WORKDIR /usr/local
-ENV GO_VERSION=1.25.7
+ENV GO_VERSION=1.26.0
 RUN export machine="$(dpkg --print-architecture)"; curl -sSOL https://go.dev/dl/go$GO_VERSION.linux-$machine.tar.gz \
   && tar -C . -xf go$GO_VERSION.linux-$machine.tar.gz \
   && rm go$GO_VERSION.linux-$machine.tar.gz
 
 # Install ruby.
 WORKDIR /home/circleci/
-ENV RUBY_VERSION=ruby-3.4.8
+ENV RUBY_VERSION=ruby-4.0.1
 ENV RUBY_FILE=$RUBY_VERSION.tar.gz
-RUN curl -sSOL https://cache.ruby-lang.org/pub/ruby/3.4/$RUBY_FILE \
+RUN curl -sSOL https://cache.ruby-lang.org/pub/ruby/4.0/$RUBY_FILE \
   && tar -C . -xzf $RUBY_FILE \
   && rm $RUBY_FILE
 
@@ -31,8 +31,8 @@ RUN ./configure \
   && make install
 
 # Install gems, https://rubygems.org/gems/rubygems-update.
-RUN gem update --system 4.0.3 \
-  && gem install bundler -v 4.0.3 \
+RUN gem update --system 4.0.6 \
+  && gem install bundler -v 4.0.6 \
   && gem install executable-hooks -v 1.7.1
 
 USER circleci

--- a/root/Makefile
+++ b/root/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=root
-VERSION:=1.63
+VERSION:=2.0
 
 include ../make/docker.mk


### PR DESCRIPTION
https://go.dev/doc/go1.26
https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/