### PR TITLE
feat(grafana): use Queueing Proxy (p99/p50)

### DIFF
--- a/grafana/services.json
+++ b/grafana/services.json
@@ -403,10 +403,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (job) (rate(rpc_server_call_duration_seconds_sum{job=~\"$service\"}[5m]))",
+          "expr": "histogram_quantile(0.99, sum by (le, job) (rate(rpc_server_call_duration_seconds_bucket{job=~\"$service\"}[5m]))) / clamp_min(histogram_quantile(0.50, sum by (le, job) (rate(rpc_server_call_duration_seconds_bucket{job=~\"$service\"}[5m]))), 1e-9)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{job}} s/s",
+          "legendFormat": "{{job}} p99/p50",
           "refId": "A"
         }
       ],
@@ -414,7 +414,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "gRPC Saturation (work s/s)",
+      "title": "gRPC Queueing Proxy (p99/p50)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -809,10 +809,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (job) (rate(http_server_request_duration_seconds_sum{job=~\"$service\"}[5m]))",
+          "expr": "histogram_quantile(0.99, sum by (le, job) (rate(http_server_request_duration_seconds_bucket{job=~\"$service\"}[5m]))) / clamp_min(histogram_quantile(0.50, sum by (le, job) (rate(http_server_request_duration_seconds_bucket{job=~\"$service\"}[5m]))), 1e-9)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{job}} s/s",
+          "legendFormat": "{{job}} p99/p50",
           "refId": "A"
         }
       ],
@@ -820,7 +820,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "HTTP Saturation (work s/s)",
+      "title": "HTTP Queueing Proxy (p99/p50)",
       "tooltip": {
         "shared": true,
         "sort": 0,


### PR DESCRIPTION

# What it means:

- ~1.0–1.5: latency is tight, little queueing.
- Higher ratio: tail latency is stretching relative to normal requests, which usually indicates queue buildup/contention/backpressure.
- Very high spikes (for example,>3 or >5): overload episodes are likely.

# Why this is useful:

- It is normalised per service baseline (unlike raw work s/s), so it is easier to compare across services and traffic levels.
- It reacts to “only some requests are waiting,” which is exactly what queueing often looks like.

# Limits to keep in mind:

- It is a proxy, not a direct queue length.
- Ratio can also rise from downstream slowness, retries, GC pauses, or lock contention.
- At very low traffic, percentiles can be noisy. The clamp_min(..., 1e-9) just prevents divide-by-zero.