### PR TITLE
feat(compose): wrapper and refresh repo docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Each top-level directory is an image (or runtime config used by the compose stac
     - `.hadolint.yaml` (image-specific hadolint rule suppressions)
 - Local dependency stack:
   - `compose.yml`
-  - `grafana/`, `prometheus/`, `status/` (config mounted into compose services)
+  - `grafana/`, `otelcol/`, `prometheus/`, `status/` (config mounted into compose services)
 - Shared build targets:
   - `make/docker.mk` (used by all image Makefiles)
 - Helper scripts:
@@ -81,7 +81,7 @@ make -C go build-docker
 
 That produces a local image tagged like:
 
-- `alexfalkowski/go:2.109` (based on `go/Makefile`)
+- `alexfalkowski/go:3.10` (based on `go/Makefile`)
 
 Build another image:
 
@@ -117,7 +117,7 @@ make -C go manifest-platform-docker
 
 This pushes two manifests:
 
-- `alexfalkowski/go:2.109`
+- `alexfalkowski/go:3.10`
 - `alexfalkowski/go` (equivalent to `:latest`)
 
 ## Compose (local dependencies)
@@ -159,16 +159,18 @@ From `compose.yml`:
 
 | Service | Image | Ports (host:container) | Notes |
 |---|---|---:|---|
-| `postgres` | `postgres:17-bullseye` | `5432:5432` | `POSTGRES_USER=test`, `POSTGRES_PASSWORD=test` |
+| `postgres` | `postgres:18-trixie` | `5432:5432` | `POSTGRES_USER=test`, `POSTGRES_PASSWORD=test` |
 | `redis` | `redis:8` | `6379:6379` |  |
-| `localstack` | `localstack/localstack:4.0` | `4566:4566` | `SERVICES=s3,sqs,ssm` |
-| `vault` | `hashicorp/vault:1.18` | `8200:8200` | dev token: `vault-plaintext-root-token` |
-| `prometheus` | `prom/prometheus:v3.1.0` | `9090:9090` | depends on `mimir` |
-| `mimir` | `grafana/mimir` | `9009:9009` |  |
-| `loki` | `grafana/loki` | `3100:3100` |  |
-| `tempo` | `grafana/tempo` | `3200:3200`, `4317:4317`, `4318:4318` | OTLP gRPC/HTTP exposed |
+| `aws` | `hectorvent/floci` | `4566:4566` | `SERVICES=s3,sqs,ssm` |
+| `vault` | `hashicorp/vault:1.21` | `8200:8200` | dev token: `vault-plaintext-root-token` |
+| `prometheus` | `prom/prometheus:v3` | `9090:9090` | depends on `mimir` |
+| `mimir` | `grafana/mimir` | `9009:9009` | mounts `./grafana` |
+| `loki` | `grafana/loki` | `3100:3100` | mounts `./grafana` |
+| `memcached` | `memcached:1.6` | `11211:11211` | cache backend for `tempo` |
+| `tempo` | `grafana/tempo:2.10.1` | `3200:3200` | depends on `memcached` |
+| `otel-collector` | `otel/opentelemetry-collector-contrib` | `4317:4317`, `4318:4318` | OTLP gRPC/HTTP ingress |
 | `grafana` | `grafana/grafana-oss` | `10000:3000` | depends on metrics/logs/traces stack |
-| `status` | `alexfalkowski/status` | `15000:8080`, `15001:6060` | mounts `./status/server.yml` |
+| `status` | `alexfalkowski/status` | `15000:8080`, `15001:6060` | mounts `./status` |
 | `flipt` | `flipt/flipt` | `8080:8080`, `9000:9000` |  |
 
 Examples:

--- a/scripts/compose
+++ b/scripts/compose
@@ -2,19 +2,13 @@
 
 set -eo pipefail
 
-if command -v docker-compose &>/dev/null; then
-  docker-compose "$@"
-  exit 0
-fi
-
 if command -v podman &>/dev/null; then
-  podman compose "$@"
-  exit 0
+  exec podman compose "$@"
 fi
 
 if command -v docker &>/dev/null; then
-  docker compose "$@"
-  exit 0
+  exec docker compose "$@"
 fi
 
+echo "expected podman or docker in PATH" >&2
 exit 1


### PR DESCRIPTION
## What

Updated `scripts/compose` to match the repo contract by preferring `podman compose` and falling back to `docker compose`, with a clearer failure message when neither tool is installed.

Refreshed `README.md` so the documented image tags, mounted config directories, and compose service inventory match the current repository state, including `aws`, `memcached`, and `otel-collector`.

## Why

The wrapper behavior had drifted from both `AGENTS.md` and the README, which made local compose usage inconsistent with the documented standard.

The README also contained stale versions and an outdated service list, which is risky in this repo because the docs are part of the expected maintenance standard and help people use the local dependency stack correctly.

## Testing

Ran `make lint`

Ran `git diff --check`

Did not run Docker image builds or start the compose stack