### PR TITLE
feat(root): clean ruby sources after install

### DIFF
--- a/root/Dockerfile
+++ b/root/Dockerfile
@@ -28,7 +28,8 @@ RUN curl -sSOL https://cache.ruby-lang.org/pub/ruby/4.0/$RUBY_FILE \
 WORKDIR /home/circleci/$RUBY_VERSION
 RUN ./configure \
   && make \
-  && make install
+  && make install \
+  && rm -rf /home/circleci/$RUBY_VERSION
 
 # Install gems, https://rubygems.org/gems/rubygems-update.
 RUN gem update --system 4.0.8 \

--- a/root/Makefile
+++ b/root/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=root
-VERSION:=2.2
+VERSION:=2.3
 
 include ../make/docker.mk


### PR DESCRIPTION
## What

Removes the Ruby source/build tree from the `root` image after `make install` so the base image does not carry `/home/circleci/ruby-4.0.2` into downstream images.

Bumps the `root` image version in `root/Makefile` from `2.2` to `2.3` to reflect the image change.

## Why

The `root` image is the base for the other images in this repository, so leaving the Ruby build directory behind increases image size and causes that extra payload to be inherited everywhere.

The version bump makes the cleanup publishable as a distinct image revision.

## Testing

Ran `make lint`

Did not build the `root` image locally