### PR TITLE
feat(release): remove trusted apt repos

### DIFF
--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -2,14 +2,20 @@ FROM alexfalkowski/root:2.3
 
 USER root
 
-# Add sources.
-RUN echo 'deb [trusted=yes] https://fury.upliftci.dev/apt/ /' | tee /etc/apt/sources.list.d/uplift.list
-RUN echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
-
-RUN apt-get update && apt-get install --no-install-recommends -y \
-  goreleaser=2.15.3 \
-  uplift=2.26.0 \
-  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# Install release tools from pinned .deb packages.
+RUN set -eux; \
+  goreleaser_version="2.15.3"; \
+  uplift_version="2.26.0"; \
+  machine="$(dpkg --print-architecture)"; \
+  goreleaser_deb="$(mktemp --suffix=.deb)"; \
+  uplift_deb="$(mktemp --suffix=.deb)"; \
+  curl -fsSL "https://github.com/goreleaser/goreleaser/releases/download/v${goreleaser_version}/goreleaser_${goreleaser_version}_${machine}.deb" -o "$goreleaser_deb"; \
+  curl -fsSL "https://github.com/gembaadvantage/uplift/releases/download/v${uplift_version}/uplift_${uplift_version}_${machine}.deb" -o "$uplift_deb"; \
+  apt-get update; \
+  apt-get install --no-install-recommends -y "$goreleaser_deb" "$uplift_deb"; \
+  apt-get clean; \
+  rm -f "$goreleaser_deb" "$uplift_deb"; \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install gh from a downloaded .deb.
 RUN set -eux; \

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=release
-VERSION:=7.8
+VERSION:=7.9
 
 include ../make/docker.mk


### PR DESCRIPTION
## What

Reworked the `release` image so `goreleaser` and `uplift` are installed from pinned GitHub release `.deb` artifacts instead of third-party APT repositories configured with `trusted=yes`.

Kept the existing pinned tool versions and architecture support by resolving the package filename from `dpkg --print-architecture` during the build.

## Why

The previous setup disabled part of APT’s repository authentication model by trusting both package sources unconditionally.

Installing pinned `.deb` release artifacts keeps the build deterministic while removing the insecure repository configuration from the image.

## Testing

Ran `make lint`

Did not build the `release` image locally