### PR TITLE
feat(sec): harden dockerfile downloads and checksum verification

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,12 +11,26 @@ RUN set -eu; \
   aarch64|arm64) hadolint_arch="arm64" ;; \
   *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
   esac; \
-  curl -fLsSLo hadolint "https://github.com/hadolint/hadolint/releases/download/v2.14.0/hadolint-linux-${hadolint_arch}" \
-  && chmod +x hadolint
+  asset="hadolint-linux-${hadolint_arch}"; \
+  base_url="https://github.com/hadolint/hadolint/releases/download/v2.14.0"; \
+  curl -fsSLo "$asset" "$base_url/$asset"; \
+  curl -fsSLo "$asset.sha256" "$base_url/$asset.sha256"; \
+  sha256sum -c "$asset.sha256"; \
+  mv "$asset" hadolint; \
+  chmod +x hadolint; \
+  rm -f "$asset.sha256"
 
 # Install shellcheck.
 ENV SHELLCHECK_VERSION=v0.11.0
-RUN export machine="$(uname -m)"; curl -sSOL https://github.com/koalaman/shellcheck/releases/download/$SHELLCHECK_VERSION/shellcheck-$SHELLCHECK_VERSION.linux.$machine.tar.xz \
-  && tar -C . -xvf shellcheck-$SHELLCHECK_VERSION.linux.$machine.tar.xz \
-  && mv shellcheck-$SHELLCHECK_VERSION/shellcheck . \
-  && rm -rf shellcheck-$SHELLCHECK_VERSION/ shellcheck-$SHELLCHECK_VERSION.linux.$machine.tar.xz
+RUN set -eu; \
+  arch="$(uname -m)"; \
+  case "$arch" in \
+  x86_64|amd64) shellcheck_arch="x86_64" ;; \
+  aarch64|arm64) shellcheck_arch="aarch64" ;; \
+  *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+  esac; \
+  asset="shellcheck-${SHELLCHECK_VERSION}.linux.${shellcheck_arch}.tar.xz"; \
+  curl -fsSLO "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/${asset}"; \
+  tar -C . -xJf "$asset"; \
+  mv shellcheck-${SHELLCHECK_VERSION}/shellcheck .; \
+  rm -rf "shellcheck-${SHELLCHECK_VERSION}" "$asset"

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=docker
-VERSION:=2.3
+VERSION:=2.4
 
 include ../make/docker.mk

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -5,16 +5,27 @@ WORKDIR /usr/local/bin
 
 # Install dockerize.
 ENV DOCKERIZE_VERSION=v0.9.3
-RUN export machine="$(dpkg --print-architecture)"; curl -sSOL https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-$machine-$DOCKERIZE_VERSION.tar.gz \
-  && tar -C . -xzvf dockerize-linux-$machine-$DOCKERIZE_VERSION.tar.gz \
-  && rm dockerize-linux-$machine-$DOCKERIZE_VERSION.tar.gz
+RUN set -eu; \
+  machine="$(dpkg --print-architecture)"; \
+  asset="dockerize-linux-${machine}-${DOCKERIZE_VERSION}.tar.gz"; \
+  curl -fsSLO "https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/${asset}"; \
+  tar -C . -xzvf "$asset"; \
+  rm -f "$asset"
 
 # Install shellcheck.
 ENV SHELLCHECK_VERSION=v0.10.0
-RUN export machine="$(uname -m)"; curl -sSOL https://github.com/koalaman/shellcheck/releases/download/$SHELLCHECK_VERSION/shellcheck-$SHELLCHECK_VERSION.linux.$machine.tar.xz \
-  && tar -C . -xvf shellcheck-$SHELLCHECK_VERSION.linux.$machine.tar.xz \
-  && mv shellcheck-$SHELLCHECK_VERSION/shellcheck . \
-  && rm -rf shellcheck-$SHELLCHECK_VERSION/ shellcheck-$SHELLCHECK_VERSION.linux.$machine.tar.xz
+RUN set -eu; \
+  arch="$(uname -m)"; \
+  case "$arch" in \
+  x86_64|amd64) shellcheck_arch="x86_64" ;; \
+  aarch64|arm64) shellcheck_arch="aarch64" ;; \
+  *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+  esac; \
+  asset="shellcheck-${SHELLCHECK_VERSION}.linux.${shellcheck_arch}.tar.xz"; \
+  curl -fsSLO "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/${asset}"; \
+  tar -C . -xJf "$asset"; \
+  mv shellcheck-${SHELLCHECK_VERSION}/shellcheck .; \
+  rm -rf "shellcheck-${SHELLCHECK_VERSION}" "$asset"
 
 # Install hadolint.
 RUN set -eu; \
@@ -24,41 +35,82 @@ RUN set -eu; \
   aarch64|arm64) hadolint_arch="arm64" ;; \
   *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
   esac; \
-  curl -fLsSLo hadolint "https://github.com/hadolint/hadolint/releases/download/v2.14.0/hadolint-linux-${hadolint_arch}" \
-  && chmod +x hadolint
+  asset="hadolint-linux-${hadolint_arch}"; \
+  base_url="https://github.com/hadolint/hadolint/releases/download/v2.14.0"; \
+  curl -fsSLo "$asset" "$base_url/$asset"; \
+  curl -fsSLo "$asset.sha256" "$base_url/$asset.sha256"; \
+  sha256sum -c "$asset.sha256"; \
+  mv "$asset" hadolint; \
+  chmod +x hadolint; \
+  rm -f "$asset.sha256"
 
 # Install buf.
-RUN export machine="$(uname -m)"; curl -sSOL https://github.com/bufbuild/buf/releases/download/v1.68.1/buf-Linux-$machine \
-  && mv buf-Linux-$machine buf \
-  && chmod +x buf
+RUN set -eu; \
+  arch="$(uname -m)"; \
+  case "$arch" in \
+  x86_64|amd64) buf_arch="x86_64" ;; \
+  aarch64|arm64) buf_arch="aarch64" ;; \
+  *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+  esac; \
+  asset="buf-Linux-${buf_arch}"; \
+  base_url="https://github.com/bufbuild/buf/releases/download/v1.68.1"; \
+  curl -fsSLo "$asset" "$base_url/$asset"; \
+  curl -fsSLo sha256.txt "$base_url/sha256.txt"; \
+  grep "  ${asset}$" sha256.txt | sha256sum -c -; \
+  mv "$asset" buf; \
+  chmod +x buf; \
+  rm -f sha256.txt
 
 # Install trivy.
-RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.70.0
+RUN set -eu; \
+  version="0.70.0"; \
+  machine="$(dpkg --print-architecture)"; \
+  case "$machine" in \
+  amd64) trivy_arch="64bit" ;; \
+  arm64) trivy_arch="ARM64" ;; \
+  *) echo "unsupported arch: $machine" >&2; exit 1 ;; \
+  esac; \
+  asset="trivy_${version}_Linux-${trivy_arch}.tar.gz"; \
+  base_url="https://github.com/aquasecurity/trivy/releases/download/v${version}"; \
+  curl -fsSLO "$base_url/$asset"; \
+  curl -fsSLO "$base_url/trivy_${version}_checksums.txt"; \
+  grep "  ${asset}$" "trivy_${version}_checksums.txt" | sha256sum -c -; \
+  tar -C . -xzf "$asset" trivy; \
+  rm -f "$asset" "trivy_${version}_checksums.txt"
 
 # Install mkcert.
-RUN export machine="$(dpkg --print-architecture)"; curl -sJLO "https://dl.filippo.io/mkcert/latest?for=linux/$machine" \
-  && mv mkcert-v*-linux-$machine mkcert \
-  && chmod +x mkcert
+ENV MKCERT_VERSION=v1.4.4
+RUN set -eu; \
+  machine="$(dpkg --print-architecture)"; \
+  asset="mkcert-${MKCERT_VERSION}-linux-${machine}"; \
+  curl -fsSLo "$asset" "https://github.com/FiloSottile/mkcert/releases/download/${MKCERT_VERSION}/${asset}"; \
+  mv "$asset" mkcert; \
+  chmod +x mkcert
 
 # Install codecov.
 RUN set -eux; \
   arch="$(uname -m)"; \
-  suffix=""; \
   case "$arch" in \
-  x86_64|amd64) suffix="" ;; \
-  aarch64|arm64) suffix="_arm64" ;; \
+  x86_64|amd64) asset="codecovcli_linux" ;; \
+  aarch64|arm64) asset="codecovcli_linux_arm64" ;; \
   *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
   esac; \
   curl -fLsSLo codecovcli \
-  "https://github.com/getsentry/prevent-cli/releases/download/v11.2.8/codecovcli_linux${suffix}"; \
+  "https://github.com/getsentry/prevent-cli/releases/download/v11.2.8/${asset}"; \
   chmod +x codecovcli
 
 # Install golangci-lint.
 ENV GO_LINT_VERSION=2.11.4
-RUN export machine="$(dpkg --print-architecture)"; curl -sSOL https://github.com/golangci/golangci-lint/releases/download/v$GO_LINT_VERSION/golangci-lint-$GO_LINT_VERSION-linux-$machine.tar.gz \
-  && tar -C . -xzvf golangci-lint-$GO_LINT_VERSION-linux-$machine.tar.gz \
-  && mv golangci-lint-$GO_LINT_VERSION-linux-$machine/golangci-lint . \
-  && rm -rf golangci-lint-$GO_LINT_VERSION-linux-$machine/ golangci-lint-$GO_LINT_VERSION-linux-$machine.tar.gz
+RUN set -eu; \
+  machine="$(dpkg --print-architecture)"; \
+  asset="golangci-lint-${GO_LINT_VERSION}-linux-${machine}.tar.gz"; \
+  base_url="https://github.com/golangci/golangci-lint/releases/download/v${GO_LINT_VERSION}"; \
+  curl -fsSLO "$base_url/$asset"; \
+  curl -fsSLO "$base_url/golangci-lint-${GO_LINT_VERSION}-checksums.txt"; \
+  grep "  ${asset}$" "golangci-lint-${GO_LINT_VERSION}-checksums.txt" | sha256sum -c -; \
+  tar -C . -xzvf "$asset"; \
+  mv "golangci-lint-${GO_LINT_VERSION}-linux-${machine}/golangci-lint" .; \
+  rm -rf "golangci-lint-${GO_LINT_VERSION}-linux-${machine}" "$asset" "golangci-lint-${GO_LINT_VERSION}-checksums.txt"
 
 USER circleci
 WORKDIR /home/circleci/

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=go
-VERSION:=3.11
+VERSION:=3.12
 
 include ../make/docker.mk

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -4,38 +4,85 @@ USER root
 WORKDIR /usr/local/bin
 
 # Install kubectl.
-RUN export machine="$(dpkg --print-architecture)"; curl -sSOL https://dl.k8s.io/release/v1.35.1/bin/linux/$machine/kubectl \
-  && chmod +x kubectl
+RUN set -eu; \
+  machine="$(dpkg --print-architecture)"; \
+  base_url="https://dl.k8s.io/release/v1.35.1/bin/linux/${machine}"; \
+  curl -fsSLo kubectl "$base_url/kubectl"; \
+  curl -fsSLo kubectl.sha256 "$base_url/kubectl.sha256"; \
+  echo "$(cat kubectl.sha256)  kubectl" | sha256sum -c -; \
+  chmod +x kubectl; \
+  rm -f kubectl.sha256
 
 # Install vegeta.
 ARG VEGETA_VERSION=12.12.0
-RUN export machine="$(dpkg --print-architecture)"; curl -sSOL https://github.com/tsenart/vegeta/releases/download/v${VEGETA_VERSION}/vegeta_${VEGETA_VERSION}_linux_$machine.tar.gz \
-  && tar C . -xf vegeta_${VEGETA_VERSION}_linux_$machine.tar.gz \
-  && rm -rf vegeta_${VEGETA_VERSION}_linux_$machine.tar.gz \
-  && chmod +x vegeta
+RUN set -eu; \
+  machine="$(dpkg --print-architecture)"; \
+  asset="vegeta_${VEGETA_VERSION}_linux_${machine}.tar.gz"; \
+  base_url="https://github.com/tsenart/vegeta/releases/download/v${VEGETA_VERSION}"; \
+  curl -fsSLO "$base_url/$asset"; \
+  curl -fsSLO "$base_url/vegeta_${VEGETA_VERSION}_checksums.txt"; \
+  grep "  ${asset}$" "vegeta_${VEGETA_VERSION}_checksums.txt" | sha256sum -c -; \
+  tar -C . -xf "$asset"; \
+  rm -f "$asset" "vegeta_${VEGETA_VERSION}_checksums.txt"; \
+  chmod +x vegeta
 
 # Install helm.
 ARG HELM_VERSION=v4.1.1
-RUN export machine="$(dpkg --print-architecture)"; curl -sSOL https://get.helm.sh/helm-${HELM_VERSION}-linux-$machine.tar.gz \
-  && tar C . -xf helm-${HELM_VERSION}-linux-$machine.tar.gz \
-  && mv linux-$machine/helm . \
-  && rm -rf linux-$machine \
-  && rm helm-${HELM_VERSION}-linux-$machine.tar.gz
+RUN set -eu; \
+  machine="$(dpkg --print-architecture)"; \
+  asset="helm-${HELM_VERSION}-linux-${machine}.tar.gz"; \
+  base_url="https://get.helm.sh"; \
+  curl -fsSLO "$base_url/$asset"; \
+  curl -fsSLO "$base_url/$asset.sha256sum"; \
+  sha256sum -c "$asset.sha256sum"; \
+  tar -C . -xf "$asset"; \
+  mv "linux-${machine}/helm" .; \
+  rm -rf "linux-${machine}" "$asset" "$asset.sha256sum"
 
 # Install doctl.
 ARG DOCTL_VERSION=1.155.0
-RUN export machine="$(dpkg --print-architecture)"; curl -sSOL https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-$machine.tar.gz \
-  && tar C . -xf doctl-${DOCTL_VERSION}-linux-$machine.tar.gz \
-  && rm doctl-${DOCTL_VERSION}-linux-$machine.tar.gz
+RUN set -eu; \
+  machine="$(dpkg --print-architecture)"; \
+  asset="doctl-${DOCTL_VERSION}-linux-${machine}.tar.gz"; \
+  base_url="https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}"; \
+  curl -fsSLO "$base_url/$asset"; \
+  curl -fsSLO "$base_url/doctl-${DOCTL_VERSION}-checksums.sha256"; \
+  grep "  ${asset}$" "doctl-${DOCTL_VERSION}-checksums.sha256" | sha256sum -c -; \
+  tar -C . -xf "$asset"; \
+  rm -f "$asset" "doctl-${DOCTL_VERSION}-checksums.sha256"
 
 # Install kubescape.
-RUN curl -s https://raw.githubusercontent.com/kubescape/kubescape/master/install.sh | /bin/bash -s -- -v v4.0.5
+RUN set -eu; \
+  version="4.0.5"; \
+  machine="$(dpkg --print-architecture)"; \
+  asset="kubescape_${version}_linux_${machine}.tar.gz"; \
+  base_url="https://github.com/kubescape/kubescape/releases/download/v${version}"; \
+  curl -fsSLO "$base_url/$asset"; \
+  curl -fsSLO "$base_url/checksums.sha256"; \
+  grep "  ${asset}$" checksums.sha256 | sha256sum -c -; \
+  tar -C . -xzf "$asset" kubescape; \
+  rm -f "$asset" checksums.sha256
 
 USER circleci
 WORKDIR /home/circleci/
 
 # Install pulumi.
-RUN curl -fsSL https://get.pulumi.com | sh -s -- --version 3.231.0
+RUN set -eux; \
+  version="3.231.0"; \
+  machine="$(dpkg --print-architecture)"; \
+  case "$machine" in \
+  amd64) pulumi_arch="x64" ;; \
+  arm64) pulumi_arch="arm64" ;; \
+  *) echo "unsupported arch: $machine" >&2; exit 1 ;; \
+  esac; \
+  asset="pulumi-v${version}-linux-${pulumi_arch}.tar.gz"; \
+  base_url="https://github.com/pulumi/pulumi/releases/download/v${version}"; \
+  curl -fsSLO "$base_url/$asset"; \
+  curl -fsSLO "$base_url/pulumi-${version}-checksums.txt"; \
+  grep "  ${asset}$" "pulumi-${version}-checksums.txt" | sha256sum -c -; \
+  tar -xzf "$asset"; \
+  mv pulumi .pulumi; \
+  rm -f "$asset" "pulumi-${version}-checksums.txt"
 ENV PATH=/home/circleci/.pulumi/bin:$PATH
 
 # Install go tools.

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -7,25 +7,31 @@ RUN set -eux; \
   goreleaser_version="2.15.3"; \
   uplift_version="2.26.0"; \
   machine="$(dpkg --print-architecture)"; \
-  goreleaser_deb="$(mktemp --suffix=.deb)"; \
-  uplift_deb="$(mktemp --suffix=.deb)"; \
-  curl -fsSL "https://github.com/goreleaser/goreleaser/releases/download/v${goreleaser_version}/goreleaser_${goreleaser_version}_${machine}.deb" -o "$goreleaser_deb"; \
-  curl -fsSL "https://github.com/gembaadvantage/uplift/releases/download/v${uplift_version}/uplift_${uplift_version}_${machine}.deb" -o "$uplift_deb"; \
+  goreleaser_deb="goreleaser_${goreleaser_version}_${machine}.deb"; \
+  uplift_deb="uplift_${uplift_version}_${machine}.deb"; \
+  curl -fsSLO "https://github.com/goreleaser/goreleaser/releases/download/v${goreleaser_version}/${goreleaser_deb}"; \
+  curl -fsSLO "https://github.com/goreleaser/goreleaser/releases/download/v${goreleaser_version}/checksums.txt"; \
+  grep "  ${goreleaser_deb}$" checksums.txt | sha256sum -c -; \
+  curl -fsSLO "https://github.com/gembaadvantage/uplift/releases/download/v${uplift_version}/${uplift_deb}"; \
+  curl -fsSLo uplift-checksums.txt "https://github.com/gembaadvantage/uplift/releases/download/v${uplift_version}/checksums.txt"; \
+  grep "  ${uplift_deb}$" uplift-checksums.txt | sha256sum -c -; \
   apt-get update; \
-  apt-get install --no-install-recommends -y "$goreleaser_deb" "$uplift_deb"; \
+  apt-get install --no-install-recommends -y "./${goreleaser_deb}" "./${uplift_deb}"; \
   apt-get clean; \
-  rm -f "$goreleaser_deb" "$uplift_deb"; \
+  rm -f "$goreleaser_deb" "$uplift_deb" checksums.txt uplift-checksums.txt; \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install gh from a downloaded .deb.
 RUN set -eux; \
   version="2.90.0"; \
   machine="$(dpkg --print-architecture)"; \
-  url="https://github.com/cli/cli/releases/download/v${version}/gh_${version}_linux_${machine}.deb"; \
-  out="$(mktemp)"; \
-  curl -fsSL "$url" -o "$out"; \
-  dpkg -i "$out"; \
-  rm -f "$out"
+  asset="gh_${version}_linux_${machine}.deb"; \
+  base_url="https://github.com/cli/cli/releases/download/v${version}"; \
+  curl -fsSLO "$base_url/$asset"; \
+  curl -fsSLO "$base_url/gh_${version}_checksums.txt"; \
+  grep "  ${asset}$" "gh_${version}_checksums.txt" | sha256sum -c -; \
+  dpkg -i "$asset"; \
+  rm -f "$asset" "gh_${version}_checksums.txt"
 
 # Add uplift config.
 RUN mkdir /etc/uplift

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=release
-VERSION:=7.9
+VERSION:=7.10
 
 include ../make/docker.mk

--- a/root/Dockerfile
+++ b/root/Dockerfile
@@ -13,15 +13,18 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 # Install go
 WORKDIR /usr/local
 ENV GO_VERSION=1.26.2
-RUN export machine="$(dpkg --print-architecture)"; curl -sSOL https://go.dev/dl/go$GO_VERSION.linux-$machine.tar.gz \
-  && tar -C . -xf go$GO_VERSION.linux-$machine.tar.gz \
-  && rm go$GO_VERSION.linux-$machine.tar.gz
+RUN set -eu; \
+  machine="$(dpkg --print-architecture)"; \
+  asset="go${GO_VERSION}.linux-${machine}.tar.gz"; \
+  curl -fsSLO "https://go.dev/dl/${asset}"; \
+  tar -C . -xf "$asset"; \
+  rm -f "$asset"
 
 # Install ruby.
 WORKDIR /home/circleci/
 ENV RUBY_VERSION=ruby-4.0.2
 ENV RUBY_FILE=$RUBY_VERSION.tar.gz
-RUN curl -sSOL https://cache.ruby-lang.org/pub/ruby/4.0/$RUBY_FILE \
+RUN curl -fsSLO https://cache.ruby-lang.org/pub/ruby/4.0/$RUBY_FILE \
   && tar -C . -xzf $RUBY_FILE \
   && rm $RUBY_FILE
 
@@ -38,9 +41,12 @@ RUN gem update --system 4.0.8 \
 
 # Install bazelisk.
 WORKDIR /usr/local/bin
-RUN export machine="$(dpkg --print-architecture)"; curl -sSOL https://github.com/bazelbuild/bazelisk/releases/download/v1.28.1/bazelisk-linux-$machine \
-  && mv bazelisk-linux-$machine bazelisk \
-  && chmod +x bazelisk
+RUN set -eu; \
+  machine="$(dpkg --print-architecture)"; \
+  asset="bazelisk-linux-${machine}"; \
+  curl -fsSLo "$asset" "https://github.com/bazelbuild/bazelisk/releases/download/v1.28.1/${asset}"; \
+  mv "$asset" bazelisk; \
+  chmod +x bazelisk
 
 USER circleci
 WORKDIR /home/circleci/

--- a/root/Makefile
+++ b/root/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=root
-VERSION:=2.3
+VERSION:=2.4
 
 include ../make/docker.mk

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -5,16 +5,27 @@ WORKDIR /usr/local/bin
 
 # Install dockerize.
 ENV DOCKERIZE_VERSION=v0.9.3
-RUN export machine="$(dpkg --print-architecture)"; curl -sSOL https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-$machine-$DOCKERIZE_VERSION.tar.gz \
-  && tar -C . -xzvf dockerize-linux-$machine-$DOCKERIZE_VERSION.tar.gz \
-  && rm dockerize-linux-$machine-$DOCKERIZE_VERSION.tar.gz
+RUN set -eu; \
+  machine="$(dpkg --print-architecture)"; \
+  asset="dockerize-linux-${machine}-${DOCKERIZE_VERSION}.tar.gz"; \
+  curl -fsSLO "https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/${asset}"; \
+  tar -C . -xzvf "$asset"; \
+  rm -f "$asset"
 
 # Install shellcheck.
 ENV SHELLCHECK_VERSION=v0.10.0
-RUN export machine="$(uname -m)"; curl -sSOL https://github.com/koalaman/shellcheck/releases/download/$SHELLCHECK_VERSION/shellcheck-$SHELLCHECK_VERSION.linux.$machine.tar.xz \
-  && tar -C . -xvf shellcheck-$SHELLCHECK_VERSION.linux.$machine.tar.xz \
-  && mv shellcheck-$SHELLCHECK_VERSION/shellcheck . \
-  && rm -rf shellcheck-$SHELLCHECK_VERSION/ shellcheck-$SHELLCHECK_VERSION.linux.$machine.tar.xz
+RUN set -eu; \
+  arch="$(uname -m)"; \
+  case "$arch" in \
+  x86_64|amd64) shellcheck_arch="x86_64" ;; \
+  aarch64|arm64) shellcheck_arch="aarch64" ;; \
+  *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+  esac; \
+  asset="shellcheck-${SHELLCHECK_VERSION}.linux.${shellcheck_arch}.tar.xz"; \
+  curl -fsSLO "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/${asset}"; \
+  tar -C . -xJf "$asset"; \
+  mv shellcheck-${SHELLCHECK_VERSION}/shellcheck .; \
+  rm -rf "shellcheck-${SHELLCHECK_VERSION}" "$asset"
 
 # Install hadolint.
 RUN set -eu; \
@@ -24,33 +35,68 @@ RUN set -eu; \
   aarch64|arm64) hadolint_arch="arm64" ;; \
   *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
   esac; \
-  curl -fLsSLo hadolint "https://github.com/hadolint/hadolint/releases/download/v2.14.0/hadolint-linux-${hadolint_arch}" \
-  && chmod +x hadolint
+  asset="hadolint-linux-${hadolint_arch}"; \
+  base_url="https://github.com/hadolint/hadolint/releases/download/v2.14.0"; \
+  curl -fsSLo "$asset" "$base_url/$asset"; \
+  curl -fsSLo "$asset.sha256" "$base_url/$asset.sha256"; \
+  sha256sum -c "$asset.sha256"; \
+  mv "$asset" hadolint; \
+  chmod +x hadolint; \
+  rm -f "$asset.sha256"
 
 # Install buf.
-RUN export machine="$(uname -m)"; curl -sSOL https://github.com/bufbuild/buf/releases/download/v1.68.1/buf-Linux-$machine \
-  && mv buf-Linux-$machine buf \
-  && chmod +x buf
+RUN set -eu; \
+  arch="$(uname -m)"; \
+  case "$arch" in \
+  x86_64|amd64) buf_arch="x86_64" ;; \
+  aarch64|arm64) buf_arch="aarch64" ;; \
+  *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+  esac; \
+  asset="buf-Linux-${buf_arch}"; \
+  base_url="https://github.com/bufbuild/buf/releases/download/v1.68.1"; \
+  curl -fsSLo "$asset" "$base_url/$asset"; \
+  curl -fsSLo sha256.txt "$base_url/sha256.txt"; \
+  grep "  ${asset}$" sha256.txt | sha256sum -c -; \
+  mv "$asset" buf; \
+  chmod +x buf; \
+  rm -f sha256.txt
 
 # Install trivy.
-RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.70.0
+RUN set -eu; \
+  version="0.70.0"; \
+  machine="$(dpkg --print-architecture)"; \
+  case "$machine" in \
+  amd64) trivy_arch="64bit" ;; \
+  arm64) trivy_arch="ARM64" ;; \
+  *) echo "unsupported arch: $machine" >&2; exit 1 ;; \
+  esac; \
+  asset="trivy_${version}_Linux-${trivy_arch}.tar.gz"; \
+  base_url="https://github.com/aquasecurity/trivy/releases/download/v${version}"; \
+  curl -fsSLO "$base_url/$asset"; \
+  curl -fsSLO "$base_url/trivy_${version}_checksums.txt"; \
+  grep "  ${asset}$" "trivy_${version}_checksums.txt" | sha256sum -c -; \
+  tar -C . -xzf "$asset" trivy; \
+  rm -f "$asset" "trivy_${version}_checksums.txt"
 
 # Install mkcert.
-RUN export machine="$(dpkg --print-architecture)"; curl -sJLO "https://dl.filippo.io/mkcert/latest?for=linux/$machine" \
-  && mv mkcert-v*-linux-$machine mkcert \
-  && chmod +x mkcert
+ENV MKCERT_VERSION=v1.4.4
+RUN set -eu; \
+  machine="$(dpkg --print-architecture)"; \
+  asset="mkcert-${MKCERT_VERSION}-linux-${machine}"; \
+  curl -fsSLo "$asset" "https://github.com/FiloSottile/mkcert/releases/download/${MKCERT_VERSION}/${asset}"; \
+  mv "$asset" mkcert; \
+  chmod +x mkcert
 
 # Install codecov.
 RUN set -eux; \
   arch="$(uname -m)"; \
-  suffix=""; \
   case "$arch" in \
-  x86_64|amd64) suffix="" ;; \
-  aarch64|arm64) suffix="_arm64" ;; \
+  x86_64|amd64) asset="codecovcli_linux" ;; \
+  aarch64|arm64) asset="codecovcli_linux_arm64" ;; \
   *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
   esac; \
   curl -fLsSLo codecovcli \
-  "https://github.com/getsentry/prevent-cli/releases/download/v11.2.8/codecovcli_linux${suffix}"; \
+  "https://github.com/getsentry/prevent-cli/releases/download/v11.2.8/${asset}"; \
   chmod +x codecovcli
 
 USER circleci

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=ruby
-VERSION:=2.7
+VERSION:=2.8
 
 include ../make/docker.mk


### PR DESCRIPTION
## What

Updated the image Dockerfiles in `docker/`, `go/`, `ruby/`, `k8s/`, `release/`, and `root/` to stop relying on insecure or overly-mutable install flows.

Replaced the remaining `curl | sh` and `curl | bash` installers with direct pinned asset downloads in the `go`, `ruby`, and `k8s` images.

Reworked the `release` image to install `goreleaser`, `uplift`, and `gh` from pinned release artifacts instead of untrusted APT repository configuration.

Added checksum verification only where the upstream source publishes checksum files or checksum endpoints, and removed the hand-maintained inline digests so version bumps are less painful to maintain.

Kept the earlier `root` image cleanup so the Ruby source tree is removed after install rather than being inherited by downstream images.

## Why

The previous Dockerfiles had two main supply-chain problems: direct execution of remote install scripts and package installation paths that trusted external sources too broadly.

Moving to pinned release assets makes the builds more deterministic and easier to audit.

Limiting checksum verification to upstream-published checksum sources keeps the hardening benefits without forcing every future version bump to also update manually curated hashes in the Dockerfiles.

## Testing

Ran `make lint`

Ran `git diff --check`

Did not build the Docker images locally