### PR TITLE
fix(k8s): pulumi install path in k8s image

### DIFF
--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -63,9 +63,6 @@ RUN set -eu; \
   tar -C . -xzf "$asset" kubescape; \
   rm -f "$asset" checksums.sha256
 
-USER circleci
-WORKDIR /home/circleci/
-
 # Install pulumi.
 RUN set -eux; \
   version="3.231.0"; \
@@ -80,10 +77,11 @@ RUN set -eux; \
   curl -fsSLO "$base_url/$asset"; \
   curl -fsSLO "$base_url/pulumi-${version}-checksums.txt"; \
   grep "  ${asset}$" "pulumi-${version}-checksums.txt" | sha256sum -c -; \
-  tar -xzf "$asset"; \
-  mv pulumi .pulumi; \
+  tar -xzf "$asset" --strip-components=1; \
   rm -f "$asset" "pulumi-${version}-checksums.txt"
-ENV PATH=/home/circleci/.pulumi/bin:$PATH
+
+USER circleci
+WORKDIR /home/circleci/
 
 # Install go tools.
 RUN go install github.com/zegl/kube-score/cmd/kube-score@v1.20.0 \

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=k8s
-VERSION:=3.9
+VERSION:=3.10
 
 include ../make/docker.mk


### PR DESCRIPTION
## What

Updated the Pulumi install in `k8s/Dockerfile` to unpack the release archive directly into `/usr/local/bin` instead of moving the extracted `pulumi/` directory into the `circleci` home directory and relying on a custom `PATH`.

Removed the now-unnecessary home-directory Pulumi path setup and kept the user switch to `circleci` only for the later Go tool install step.

## Why

CI was failing with `pulumi: No such file or directory` on both `amd64` and `arm64`.

The Pulumi release archives themselves are valid on both architectures, so the fragile part was how the image was placing the binaries after extraction. Installing them into `/usr/local/bin` matches the rest of the image’s CLI tooling and avoids path/layout issues.

## Testing

Ran `make lint`

Ran `git diff --check`

Did not build the `k8s` image locally