### PR TITLE
feat(scripts): extract image tool installs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.circleci
+bin

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,34 +3,11 @@ FROM alexfalkowski/root:2.6
 USER root
 WORKDIR /usr/local/bin
 
-# Install hadolint.
-RUN set -eu; \
-  arch="$(uname -m)"; \
-  case "$arch" in \
-  x86_64|amd64) hadolint_arch="x86_64" ;; \
-  aarch64|arm64) hadolint_arch="arm64" ;; \
-  *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
-  esac; \
-  asset="hadolint-linux-${hadolint_arch}"; \
-  base_url="https://github.com/hadolint/hadolint/releases/download/v2.14.0"; \
-  curl -fsSLo "$asset" "$base_url/$asset"; \
-  curl -fsSLo "$asset.sha256" "$base_url/$asset.sha256"; \
-  sha256sum -c "$asset.sha256"; \
-  mv "$asset" hadolint; \
-  chmod +x hadolint; \
-  rm -f "$asset.sha256"
-
-# Install shellcheck.
+ARG HADOLINT_VERSION=v2.14.0
 ENV SHELLCHECK_VERSION=v0.11.0
-RUN set -eu; \
-  arch="$(uname -m)"; \
-  case "$arch" in \
-  x86_64|amd64) shellcheck_arch="x86_64" ;; \
-  aarch64|arm64) shellcheck_arch="aarch64" ;; \
-  *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
-  esac; \
-  asset="shellcheck-${SHELLCHECK_VERSION}.linux.${shellcheck_arch}.tar.xz"; \
-  curl -fsSLO "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/${asset}"; \
-  tar -C . -xJf "$asset"; \
-  mv shellcheck-${SHELLCHECK_VERSION}/shellcheck .; \
-  rm -rf "shellcheck-${SHELLCHECK_VERSION}" "$asset"
+
+COPY scripts/install-image-tool /usr/local/bin/install-image-tool
+COPY docker/scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
+RUN chmod +x /usr/local/bin/install-image-tool \
+  && install-image-tool hadolint \
+  && install-image-tool shellcheck

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=docker
-VERSION:=2.7
+VERSION:=2.8
 
 include ../make/docker.mk

--- a/docker/scripts/install-image-tool.d/hadolint
+++ b/docker/scripts/install-image-tool.d/hadolint
@@ -1,0 +1,18 @@
+# shellcheck shell=bash
+
+version="${HADOLINT_VERSION:-v2.14.0}"
+
+case "$(uname -m)" in
+  x86_64 | amd64) arch="x86_64" ;;
+  aarch64 | arm64) arch="arm64" ;;
+  *) unsupported_arch "$(uname -m)" ;;
+esac
+
+asset="hadolint-linux-${arch}"
+base_url="https://github.com/hadolint/hadolint/releases/download/${version}"
+
+download "$base_url/$asset" "$asset"
+download "$base_url/$asset.sha256" "$asset.sha256"
+sha256sum -c "$asset.sha256"
+
+install_binary "$asset" hadolint

--- a/docker/scripts/install-image-tool.d/shellcheck
+++ b/docker/scripts/install-image-tool.d/shellcheck
@@ -1,0 +1,17 @@
+# shellcheck shell=bash
+
+version="${SHELLCHECK_VERSION:-v0.11.0}"
+
+case "$(uname -m)" in
+  x86_64 | amd64) arch="x86_64" ;;
+  aarch64 | arm64) arch="aarch64" ;;
+  *) unsupported_arch "$(uname -m)" ;;
+esac
+
+asset="shellcheck-${version}.linux.${arch}.tar.xz"
+base_url="https://github.com/koalaman/shellcheck/releases/download/${version}"
+
+download "$base_url/$asset" "$asset"
+
+tar -xJf "$asset"
+install_binary "shellcheck-${version}/shellcheck" shellcheck

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -3,114 +3,26 @@ FROM alexfalkowski/root:2.6
 USER root
 WORKDIR /usr/local/bin
 
-# Install dockerize.
 ENV DOCKERIZE_VERSION=v0.9.3
-RUN set -eu; \
-  machine="$(dpkg --print-architecture)"; \
-  asset="dockerize-linux-${machine}-${DOCKERIZE_VERSION}.tar.gz"; \
-  curl -fsSLO "https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/${asset}"; \
-  tar -C . -xzvf "$asset"; \
-  rm -f "$asset"
-
-# Install shellcheck.
 ENV SHELLCHECK_VERSION=v0.10.0
-RUN set -eu; \
-  arch="$(uname -m)"; \
-  case "$arch" in \
-  x86_64|amd64) shellcheck_arch="x86_64" ;; \
-  aarch64|arm64) shellcheck_arch="aarch64" ;; \
-  *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
-  esac; \
-  asset="shellcheck-${SHELLCHECK_VERSION}.linux.${shellcheck_arch}.tar.xz"; \
-  curl -fsSLO "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/${asset}"; \
-  tar -C . -xJf "$asset"; \
-  mv shellcheck-${SHELLCHECK_VERSION}/shellcheck .; \
-  rm -rf "shellcheck-${SHELLCHECK_VERSION}" "$asset"
-
-# Install hadolint.
-RUN set -eu; \
-  arch="$(uname -m)"; \
-  case "$arch" in \
-  x86_64|amd64) hadolint_arch="x86_64" ;; \
-  aarch64|arm64) hadolint_arch="arm64" ;; \
-  *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
-  esac; \
-  asset="hadolint-linux-${hadolint_arch}"; \
-  base_url="https://github.com/hadolint/hadolint/releases/download/v2.14.0"; \
-  curl -fsSLo "$asset" "$base_url/$asset"; \
-  curl -fsSLo "$asset.sha256" "$base_url/$asset.sha256"; \
-  sha256sum -c "$asset.sha256"; \
-  mv "$asset" hadolint; \
-  chmod +x hadolint; \
-  rm -f "$asset.sha256"
-
-# Install buf.
-RUN set -eu; \
-  arch="$(uname -m)"; \
-  case "$arch" in \
-  x86_64|amd64) buf_arch="x86_64" ;; \
-  aarch64|arm64) buf_arch="aarch64" ;; \
-  *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
-  esac; \
-  asset="buf-Linux-${buf_arch}"; \
-  base_url="https://github.com/bufbuild/buf/releases/download/v1.68.4"; \
-  curl -fsSLo "$asset" "$base_url/$asset"; \
-  curl -fsSLo sha256.txt "$base_url/sha256.txt"; \
-  grep "  ${asset}$" sha256.txt | sha256sum -c -; \
-  mv "$asset" buf; \
-  chmod +x buf; \
-  rm -f sha256.txt
-
-# Install trivy.
-RUN set -eu; \
-  version="0.70.0"; \
-  machine="$(dpkg --print-architecture)"; \
-  case "$machine" in \
-  amd64) trivy_arch="64bit" ;; \
-  arm64) trivy_arch="ARM64" ;; \
-  *) echo "unsupported arch: $machine" >&2; exit 1 ;; \
-  esac; \
-  asset="trivy_${version}_Linux-${trivy_arch}.tar.gz"; \
-  base_url="https://github.com/aquasecurity/trivy/releases/download/v${version}"; \
-  curl -fsSLO "$base_url/$asset"; \
-  curl -fsSLO "$base_url/trivy_${version}_checksums.txt"; \
-  grep "  ${asset}$" "trivy_${version}_checksums.txt" | sha256sum -c -; \
-  tar -C . -xzf "$asset" trivy; \
-  rm -f "$asset" "trivy_${version}_checksums.txt"
-
-# Install mkcert.
 ENV MKCERT_VERSION=v1.4.4
-RUN set -eu; \
-  machine="$(dpkg --print-architecture)"; \
-  asset="mkcert-${MKCERT_VERSION}-linux-${machine}"; \
-  curl -fsSLo "$asset" "https://github.com/FiloSottile/mkcert/releases/download/${MKCERT_VERSION}/${asset}"; \
-  mv "$asset" mkcert; \
-  chmod +x mkcert
-
-# Install codecov.
-RUN set -eux; \
-  arch="$(uname -m)"; \
-  case "$arch" in \
-  x86_64|amd64) asset="codecovcli_linux" ;; \
-  aarch64|arm64) asset="codecovcli_linux_arm64" ;; \
-  *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
-  esac; \
-  curl -fLsSLo codecovcli \
-  "https://github.com/getsentry/prevent-cli/releases/download/v11.2.8/${asset}"; \
-  chmod +x codecovcli
-
-# Install golangci-lint.
 ENV GO_LINT_VERSION=2.11.4
-RUN set -eu; \
-  machine="$(dpkg --print-architecture)"; \
-  asset="golangci-lint-${GO_LINT_VERSION}-linux-${machine}.tar.gz"; \
-  base_url="https://github.com/golangci/golangci-lint/releases/download/v${GO_LINT_VERSION}"; \
-  curl -fsSLO "$base_url/$asset"; \
-  curl -fsSLO "$base_url/golangci-lint-${GO_LINT_VERSION}-checksums.txt"; \
-  grep "  ${asset}$" "golangci-lint-${GO_LINT_VERSION}-checksums.txt" | sha256sum -c -; \
-  tar -C . -xzvf "$asset"; \
-  mv "golangci-lint-${GO_LINT_VERSION}-linux-${machine}/golangci-lint" .; \
-  rm -rf "golangci-lint-${GO_LINT_VERSION}-linux-${machine}" "$asset" "golangci-lint-${GO_LINT_VERSION}-checksums.txt"
+ARG HADOLINT_VERSION=v2.14.0
+ARG BUF_VERSION=v1.68.4
+ARG TRIVY_VERSION=0.70.0
+ARG CODECOV_VERSION=v11.2.8
+
+COPY scripts/install-image-tool /usr/local/bin/install-image-tool
+COPY go/scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
+RUN chmod +x /usr/local/bin/install-image-tool \
+  && install-image-tool dockerize \
+  && install-image-tool shellcheck \
+  && install-image-tool hadolint \
+  && install-image-tool buf \
+  && install-image-tool trivy \
+  && install-image-tool mkcert \
+  && install-image-tool codecov \
+  && install-image-tool golangci-lint
 
 USER circleci
 WORKDIR /home/circleci/

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=go
-VERSION:=3.18
+VERSION:=3.19
 
 include ../make/docker.mk

--- a/go/scripts/install-image-tool.d/buf
+++ b/go/scripts/install-image-tool.d/buf
@@ -1,0 +1,18 @@
+# shellcheck shell=bash
+
+version="${BUF_VERSION:-v1.68.4}"
+
+case "$(uname -m)" in
+  x86_64 | amd64) arch="x86_64" ;;
+  aarch64 | arm64) arch="aarch64" ;;
+  *) unsupported_arch "$(uname -m)" ;;
+esac
+
+asset="buf-Linux-${arch}"
+base_url="https://github.com/bufbuild/buf/releases/download/${version}"
+
+download "$base_url/$asset" "$asset"
+download "$base_url/sha256.txt" sha256.txt
+verify_checksum_file sha256.txt "$asset"
+
+install_binary "$asset" buf

--- a/go/scripts/install-image-tool.d/codecov
+++ b/go/scripts/install-image-tool.d/codecov
@@ -1,0 +1,14 @@
+# shellcheck shell=bash
+
+version="${CODECOV_VERSION:-v11.2.8}"
+
+case "$(uname -m)" in
+  x86_64 | amd64) asset="codecovcli_linux" ;;
+  aarch64 | arm64) asset="codecovcli_linux_arm64" ;;
+  *) unsupported_arch "$(uname -m)" ;;
+esac
+
+base_url="https://github.com/getsentry/prevent-cli/releases/download/${version}"
+
+download "$base_url/$asset" codecovcli
+install_binary codecovcli codecovcli

--- a/go/scripts/install-image-tool.d/dockerize
+++ b/go/scripts/install-image-tool.d/dockerize
@@ -1,0 +1,11 @@
+# shellcheck shell=bash
+
+version="${DOCKERIZE_VERSION:-v0.9.3}"
+arch="$(debian_arch)"
+asset="dockerize-linux-${arch}-${version}.tar.gz"
+base_url="https://github.com/jwilder/dockerize/releases/download/${version}"
+
+download "$base_url/$asset" "$asset"
+
+tar -xzf "$asset"
+install_binary dockerize dockerize

--- a/go/scripts/install-image-tool.d/golangci-lint
+++ b/go/scripts/install-image-tool.d/golangci-lint
@@ -1,0 +1,14 @@
+# shellcheck shell=bash
+
+version="${GO_LINT_VERSION:-2.11.4}"
+arch="$(debian_arch)"
+asset="golangci-lint-${version}-linux-${arch}.tar.gz"
+base_url="https://github.com/golangci/golangci-lint/releases/download/v${version}"
+checksum_file="golangci-lint-${version}-checksums.txt"
+
+download "$base_url/$asset" "$asset"
+download "$base_url/$checksum_file" "$checksum_file"
+verify_checksum_file "$checksum_file" "$asset"
+
+tar -xzf "$asset"
+install_binary "golangci-lint-${version}-linux-${arch}/golangci-lint" golangci-lint

--- a/go/scripts/install-image-tool.d/hadolint
+++ b/go/scripts/install-image-tool.d/hadolint
@@ -1,0 +1,18 @@
+# shellcheck shell=bash
+
+version="${HADOLINT_VERSION:-v2.14.0}"
+
+case "$(uname -m)" in
+  x86_64 | amd64) arch="x86_64" ;;
+  aarch64 | arm64) arch="arm64" ;;
+  *) unsupported_arch "$(uname -m)" ;;
+esac
+
+asset="hadolint-linux-${arch}"
+base_url="https://github.com/hadolint/hadolint/releases/download/${version}"
+
+download "$base_url/$asset" "$asset"
+download "$base_url/$asset.sha256" "$asset.sha256"
+sha256sum -c "$asset.sha256"
+
+install_binary "$asset" hadolint

--- a/go/scripts/install-image-tool.d/mkcert
+++ b/go/scripts/install-image-tool.d/mkcert
@@ -1,0 +1,9 @@
+# shellcheck shell=bash
+
+version="${MKCERT_VERSION:-v1.4.4}"
+arch="$(debian_arch)"
+asset="mkcert-${version}-linux-${arch}"
+base_url="https://github.com/FiloSottile/mkcert/releases/download/${version}"
+
+download "$base_url/$asset" "$asset"
+install_binary "$asset" mkcert

--- a/go/scripts/install-image-tool.d/shellcheck
+++ b/go/scripts/install-image-tool.d/shellcheck
@@ -1,0 +1,17 @@
+# shellcheck shell=bash
+
+version="${SHELLCHECK_VERSION:-v0.10.0}"
+
+case "$(uname -m)" in
+  x86_64 | amd64) arch="x86_64" ;;
+  aarch64 | arm64) arch="aarch64" ;;
+  *) unsupported_arch "$(uname -m)" ;;
+esac
+
+asset="shellcheck-${version}.linux.${arch}.tar.xz"
+base_url="https://github.com/koalaman/shellcheck/releases/download/${version}"
+
+download "$base_url/$asset" "$asset"
+
+tar -xJf "$asset"
+install_binary "shellcheck-${version}/shellcheck" shellcheck

--- a/go/scripts/install-image-tool.d/trivy
+++ b/go/scripts/install-image-tool.d/trivy
@@ -1,0 +1,20 @@
+# shellcheck shell=bash
+
+version="${TRIVY_VERSION:-0.70.0}"
+
+case "$(debian_arch)" in
+  amd64) arch="64bit" ;;
+  arm64) arch="ARM64" ;;
+  *) unsupported_arch "$(debian_arch)" ;;
+esac
+
+asset="trivy_${version}_Linux-${arch}.tar.gz"
+base_url="https://github.com/aquasecurity/trivy/releases/download/v${version}"
+checksum_file="trivy_${version}_checksums.txt"
+
+download "$base_url/$asset" "$asset"
+download "$base_url/$checksum_file" "$checksum_file"
+verify_checksum_file "$checksum_file" "$asset"
+
+tar -xzf "$asset" trivy
+install_binary trivy trivy

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -3,82 +3,22 @@ FROM alexfalkowski/root:2.6
 USER root
 WORKDIR /usr/local/bin
 
-# Install kubectl.
-RUN set -eu; \
-  machine="$(dpkg --print-architecture)"; \
-  base_url="https://dl.k8s.io/release/v1.36.0/bin/linux/${machine}"; \
-  curl -fsSLo kubectl "$base_url/kubectl"; \
-  curl -fsSLo kubectl.sha256 "$base_url/kubectl.sha256"; \
-  echo "$(cat kubectl.sha256)  kubectl" | sha256sum -c -; \
-  chmod +x kubectl; \
-  rm -f kubectl.sha256
-
-# Install vegeta.
+ARG KUBECTL_VERSION=1.36.0
 ARG VEGETA_VERSION=12.12.0
-RUN set -eu; \
-  machine="$(dpkg --print-architecture)"; \
-  asset="vegeta_${VEGETA_VERSION}_linux_${machine}.tar.gz"; \
-  base_url="https://github.com/tsenart/vegeta/releases/download/v${VEGETA_VERSION}"; \
-  curl -fsSLO "$base_url/$asset"; \
-  curl -fsSLO "$base_url/vegeta_${VEGETA_VERSION}_checksums.txt"; \
-  grep "  ${asset}$" "vegeta_${VEGETA_VERSION}_checksums.txt" | sha256sum -c -; \
-  tar -C . -xf "$asset"; \
-  rm -f "$asset" "vegeta_${VEGETA_VERSION}_checksums.txt"; \
-  chmod +x vegeta
-
-# Install helm.
 ARG HELM_VERSION=v4.1.1
-RUN set -eu; \
-  machine="$(dpkg --print-architecture)"; \
-  asset="helm-${HELM_VERSION}-linux-${machine}.tar.gz"; \
-  base_url="https://get.helm.sh"; \
-  curl -fsSLO "$base_url/$asset"; \
-  curl -fsSLO "$base_url/$asset.sha256sum"; \
-  sha256sum -c "$asset.sha256sum"; \
-  tar -C . -xf "$asset"; \
-  mv "linux-${machine}/helm" .; \
-  rm -rf "linux-${machine}" "$asset" "$asset.sha256sum"
-
-# Install doctl.
 ARG DOCTL_VERSION=1.155.0
-RUN set -eu; \
-  machine="$(dpkg --print-architecture)"; \
-  asset="doctl-${DOCTL_VERSION}-linux-${machine}.tar.gz"; \
-  base_url="https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}"; \
-  curl -fsSLO "$base_url/$asset"; \
-  curl -fsSLO "$base_url/doctl-${DOCTL_VERSION}-checksums.sha256"; \
-  grep "  ${asset}$" "doctl-${DOCTL_VERSION}-checksums.sha256" | sha256sum -c -; \
-  tar -C . -xf "$asset"; \
-  rm -f "$asset" "doctl-${DOCTL_VERSION}-checksums.sha256"
+ARG KUBESCAPE_VERSION=4.0.5
+ARG PULUMI_VERSION=3.232.0
 
-# Install kubescape.
-RUN set -eu; \
-  version="4.0.5"; \
-  machine="$(dpkg --print-architecture)"; \
-  asset="kubescape_${version}_linux_${machine}.tar.gz"; \
-  base_url="https://github.com/kubescape/kubescape/releases/download/v${version}"; \
-  curl -fsSLO "$base_url/$asset"; \
-  curl -fsSLO "$base_url/checksums.sha256"; \
-  grep "  ${asset}$" checksums.sha256 | sha256sum -c -; \
-  tar -C . -xzf "$asset" kubescape; \
-  rm -f "$asset" checksums.sha256
-
-# Install pulumi.
-RUN set -eux; \
-  version="3.232.0"; \
-  machine="$(dpkg --print-architecture)"; \
-  case "$machine" in \
-  amd64) pulumi_arch="x64" ;; \
-  arm64) pulumi_arch="arm64" ;; \
-  *) echo "unsupported arch: $machine" >&2; exit 1 ;; \
-  esac; \
-  asset="pulumi-v${version}-linux-${pulumi_arch}.tar.gz"; \
-  base_url="https://github.com/pulumi/pulumi/releases/download/v${version}"; \
-  curl -fsSLO "$base_url/$asset"; \
-  curl -fsSLO "$base_url/pulumi-${version}-checksums.txt"; \
-  grep "  ${asset}$" "pulumi-${version}-checksums.txt" | sha256sum -c -; \
-  tar -xzf "$asset" --strip-components=1; \
-  rm -f "$asset" "pulumi-${version}-checksums.txt"
+COPY scripts/install-image-tool /usr/local/bin/install-image-tool
+COPY k8s/scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
+RUN chmod +x /usr/local/bin/install-image-tool \
+  && install-image-tool kubectl \
+  && install-image-tool vegeta \
+  && install-image-tool helm \
+  && install-image-tool doctl \
+  && install-image-tool kubescape \
+  && install-image-tool pulumi
 
 USER circleci
 WORKDIR /home/circleci/

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=k8s
-VERSION:=3.13
+VERSION:=3.14
 
 include ../make/docker.mk

--- a/k8s/scripts/install-image-tool.d/doctl
+++ b/k8s/scripts/install-image-tool.d/doctl
@@ -1,0 +1,14 @@
+# shellcheck shell=bash
+
+version="${DOCTL_VERSION:-1.155.0}"
+arch="$(debian_arch)"
+asset="doctl-${version}-linux-${arch}.tar.gz"
+base_url="https://github.com/digitalocean/doctl/releases/download/v${version}"
+checksum_file="doctl-${version}-checksums.sha256"
+
+download "$base_url/$asset" "$asset"
+download "$base_url/$checksum_file" "$checksum_file"
+verify_checksum_file "$checksum_file" "$asset"
+
+tar -xzf "$asset"
+install_binary doctl doctl

--- a/k8s/scripts/install-image-tool.d/helm
+++ b/k8s/scripts/install-image-tool.d/helm
@@ -1,0 +1,13 @@
+# shellcheck shell=bash
+
+version="${HELM_VERSION:-v4.1.1}"
+arch="$(debian_arch)"
+asset="helm-${version}-linux-${arch}.tar.gz"
+base_url="https://get.helm.sh"
+
+download "$base_url/$asset" "$asset"
+download "$base_url/$asset.sha256sum" "$asset.sha256sum"
+sha256sum -c "$asset.sha256sum"
+
+tar -xzf "$asset"
+install_binary "linux-${arch}/helm" helm

--- a/k8s/scripts/install-image-tool.d/kubectl
+++ b/k8s/scripts/install-image-tool.d/kubectl
@@ -1,0 +1,11 @@
+# shellcheck shell=bash
+
+version="${KUBECTL_VERSION:-1.36.0}"
+arch="$(debian_arch)"
+base_url="https://dl.k8s.io/release/v${version}/bin/linux/${arch}"
+
+download "$base_url/kubectl" kubectl
+download "$base_url/kubectl.sha256" kubectl.sha256
+verify_digest_file kubectl.sha256 kubectl
+
+install_binary kubectl kubectl

--- a/k8s/scripts/install-image-tool.d/kubescape
+++ b/k8s/scripts/install-image-tool.d/kubescape
@@ -1,0 +1,13 @@
+# shellcheck shell=bash
+
+version="${KUBESCAPE_VERSION:-4.0.5}"
+arch="$(debian_arch)"
+asset="kubescape_${version}_linux_${arch}.tar.gz"
+base_url="https://github.com/kubescape/kubescape/releases/download/v${version}"
+
+download "$base_url/$asset" "$asset"
+download "$base_url/checksums.sha256" checksums.sha256
+verify_checksum_file checksums.sha256 "$asset"
+
+tar -xzf "$asset" kubescape
+install_binary kubescape kubescape

--- a/k8s/scripts/install-image-tool.d/pulumi
+++ b/k8s/scripts/install-image-tool.d/pulumi
@@ -1,0 +1,25 @@
+# shellcheck shell=bash
+
+version="${PULUMI_VERSION:-3.232.0}"
+
+case "$(debian_arch)" in
+  amd64) arch="x64" ;;
+  arm64) arch="arm64" ;;
+  *) unsupported_arch "$(debian_arch)" ;;
+esac
+
+asset="pulumi-v${version}-linux-${arch}.tar.gz"
+base_url="https://github.com/pulumi/pulumi/releases/download/v${version}"
+checksum_file="pulumi-${version}-checksums.txt"
+
+download "$base_url/$asset" "$asset"
+download "$base_url/$checksum_file" "$checksum_file"
+verify_checksum_file "$checksum_file" "$asset"
+
+mkdir pulumi
+tar -C pulumi -xzf "$asset" --strip-components=1
+
+for binary in pulumi/*; do
+  [[ -f "$binary" ]] || continue
+  install_binary "$binary" "$(basename "$binary")"
+done

--- a/k8s/scripts/install-image-tool.d/vegeta
+++ b/k8s/scripts/install-image-tool.d/vegeta
@@ -1,0 +1,14 @@
+# shellcheck shell=bash
+
+version="${VEGETA_VERSION:-12.12.0}"
+arch="$(debian_arch)"
+asset="vegeta_${version}_linux_${arch}.tar.gz"
+base_url="https://github.com/tsenart/vegeta/releases/download/v${version}"
+checksum_file="vegeta_${version}_checksums.txt"
+
+download "$base_url/$asset" "$asset"
+download "$base_url/$checksum_file" "$checksum_file"
+verify_checksum_file "$checksum_file" "$asset"
+
+tar -xzf "$asset"
+install_binary vegeta vegeta

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -1,18 +1,18 @@
 # Build docker image.
 build-docker:
-	docker build -t alexfalkowski/$(IMAGE):$(VERSION) .
+	docker build -f Dockerfile -t alexfalkowski/$(IMAGE):$(VERSION) ..
 
 # Push built docker image.
 push-docker:
-	docker build -t alexfalkowski/$(IMAGE):$(VERSION) -t alexfalkowski/$(IMAGE) --push .
+	docker build -f Dockerfile -t alexfalkowski/$(IMAGE):$(VERSION) -t alexfalkowski/$(IMAGE) --push ..
 
 # Build platform docker image.
 build-platform-docker:
-	docker build -t alexfalkowski/$(IMAGE):$(VERSION).$(platform) .
+	docker build -f Dockerfile -t alexfalkowski/$(IMAGE):$(VERSION).$(platform) ..
 
 # Push built platform docker image.
 push-platform-docker:
-	docker build -t alexfalkowski/$(IMAGE):$(VERSION).$(platform) --push .
+	docker build -f Dockerfile -t alexfalkowski/$(IMAGE):$(VERSION).$(platform) --push ..
 
 manifest-platform-version-docker:
 	docker manifest create alexfalkowski/$(IMAGE):$(VERSION) --amend alexfalkowski/$(IMAGE):$(VERSION).amd64 --amend alexfalkowski/$(IMAGE):$(VERSION).arm64

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -2,49 +2,29 @@ FROM alexfalkowski/root:2.6
 
 USER root
 
-# Install release tools from pinned .deb packages.
-RUN set -eux; \
-  goreleaser_version="2.15.4"; \
-  uplift_version="2.26.0"; \
-  machine="$(dpkg --print-architecture)"; \
-  goreleaser_deb="goreleaser_${goreleaser_version}_${machine}.deb"; \
-  uplift_deb="uplift_${uplift_version}_${machine}.deb"; \
-  curl -fsSLO "https://github.com/goreleaser/goreleaser/releases/download/v${goreleaser_version}/${goreleaser_deb}"; \
-  curl -fsSLO "https://github.com/goreleaser/goreleaser/releases/download/v${goreleaser_version}/checksums.txt"; \
-  grep "  ${goreleaser_deb}$" checksums.txt | sha256sum -c -; \
-  curl -fsSLO "https://github.com/gembaadvantage/uplift/releases/download/v${uplift_version}/${uplift_deb}"; \
-  curl -fsSLo uplift-checksums.txt "https://github.com/gembaadvantage/uplift/releases/download/v${uplift_version}/checksums.txt"; \
-  grep "  ${uplift_deb}$" uplift-checksums.txt | sha256sum -c -; \
-  apt-get update; \
-  apt-get install --no-install-recommends -y "./${goreleaser_deb}" "./${uplift_deb}"; \
-  apt-get clean; \
-  rm -f "$goreleaser_deb" "$uplift_deb" checksums.txt uplift-checksums.txt; \
-  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ARG GORELEASER_VERSION=2.15.4
+ARG UPLIFT_VERSION=2.26.0
+ARG GH_VERSION=2.92.0
 
-# Install gh from a downloaded .deb.
-RUN set -eux; \
-  version="2.92.0"; \
-  machine="$(dpkg --print-architecture)"; \
-  asset="gh_${version}_linux_${machine}.deb"; \
-  base_url="https://github.com/cli/cli/releases/download/v${version}"; \
-  curl -fsSLO "$base_url/$asset"; \
-  curl -fsSLO "$base_url/gh_${version}_checksums.txt"; \
-  grep "  ${asset}$" "gh_${version}_checksums.txt" | sha256sum -c -; \
-  dpkg -i "$asset"; \
-  rm -f "$asset" "gh_${version}_checksums.txt"
+COPY scripts/install-image-tool /usr/local/bin/install-image-tool
+COPY release/scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
+RUN chmod +x /usr/local/bin/install-image-tool \
+  && install-image-tool goreleaser \
+  && install-image-tool uplift \
+  && install-image-tool gh
 
 # Add uplift config.
 RUN mkdir /etc/uplift
-COPY .uplift.yml /etc/uplift
+COPY release/.uplift.yml /etc/uplift
 
 # Copy scripts.
-COPY deploy /usr/local/bin/
+COPY release/deploy /usr/local/bin/
 RUN chmod +x /usr/local/bin/deploy
 
-COPY package /usr/local/bin/
+COPY release/package /usr/local/bin/
 RUN chmod +x /usr/local/bin/package
 
-COPY version /usr/local/bin/
+COPY release/version /usr/local/bin/
 RUN chmod +x /usr/local/bin/version
 
 USER circleci

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=release
-VERSION:=7.14
+VERSION:=7.15
 
 include ../make/docker.mk

--- a/release/scripts/install-image-tool.d/gh
+++ b/release/scripts/install-image-tool.d/gh
@@ -1,0 +1,13 @@
+# shellcheck shell=bash
+
+version="${GH_VERSION:-2.92.0}"
+arch="$(debian_arch)"
+asset="gh_${version}_linux_${arch}.deb"
+base_url="https://github.com/cli/cli/releases/download/v${version}"
+checksum_file="gh_${version}_checksums.txt"
+
+download "$base_url/$asset" "$asset"
+download "$base_url/$checksum_file" "$checksum_file"
+verify_checksum_file "$checksum_file" "$asset"
+
+dpkg -i "$asset"

--- a/release/scripts/install-image-tool.d/goreleaser
+++ b/release/scripts/install-image-tool.d/goreleaser
@@ -1,0 +1,15 @@
+# shellcheck shell=bash
+
+version="${GORELEASER_VERSION:-2.15.4}"
+arch="$(debian_arch)"
+asset="goreleaser_${version}_${arch}.deb"
+base_url="https://github.com/goreleaser/goreleaser/releases/download/v${version}"
+
+download "$base_url/$asset" "$asset"
+download "$base_url/checksums.txt" checksums.txt
+verify_checksum_file checksums.txt "$asset"
+
+apt-get update
+apt-get install --no-install-recommends -y "./${asset}"
+apt-get clean
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/release/scripts/install-image-tool.d/uplift
+++ b/release/scripts/install-image-tool.d/uplift
@@ -1,0 +1,15 @@
+# shellcheck shell=bash
+
+version="${UPLIFT_VERSION:-2.26.0}"
+arch="$(debian_arch)"
+asset="uplift_${version}_${arch}.deb"
+base_url="https://github.com/gembaadvantage/uplift/releases/download/v${version}"
+
+download "$base_url/$asset" "$asset"
+download "$base_url/checksums.txt" checksums.txt
+verify_checksum_file checksums.txt "$asset"
+
+apt-get update
+apt-get install --no-install-recommends -y "./${asset}"
+apt-get clean
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/root/Dockerfile
+++ b/root/Dockerfile
@@ -10,43 +10,23 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   libyaml-dev \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Install go
-WORKDIR /usr/local
 ENV GO_VERSION=1.26.2
-RUN set -eu; \
-  machine="$(dpkg --print-architecture)"; \
-  asset="go${GO_VERSION}.linux-${machine}.tar.gz"; \
-  curl -fsSLO "https://go.dev/dl/${asset}"; \
-  tar -C . -xf "$asset"; \
-  rm -f "$asset"
-
-# Install ruby.
-WORKDIR /home/circleci/
 ENV RUBY_VERSION=ruby-4.0.3
-ENV RUBY_FILE=$RUBY_VERSION.tar.gz
-RUN curl -fsSLO https://cache.ruby-lang.org/pub/ruby/4.0/$RUBY_FILE \
-  && tar -C . -xzf $RUBY_FILE \
-  && rm $RUBY_FILE
+ARG BAZELISK_VERSION=v1.29.0
 
-WORKDIR /home/circleci/$RUBY_VERSION
-RUN ./configure \
-  && make \
-  && make install \
-  && rm -rf /home/circleci/$RUBY_VERSION
+WORKDIR /usr/local/bin
+COPY scripts/install-image-tool /usr/local/bin/install-image-tool
+COPY root/scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
+RUN chmod +x /usr/local/bin/install-image-tool \
+  && install-image-tool go \
+  && install-image-tool ruby
 
 # Install gems, https://rubygems.org/gems/rubygems-update.
 RUN gem update --system 4.0.8 \
   && gem install bundler -v 4.0.8 \
   && gem install executable-hooks -v 1.7.1
 
-# Install bazelisk.
-WORKDIR /usr/local/bin
-RUN set -eu; \
-  machine="$(dpkg --print-architecture)"; \
-  asset="bazelisk-linux-${machine}"; \
-  curl -fsSLo "$asset" "https://github.com/bazelbuild/bazelisk/releases/download/v1.29.0/${asset}"; \
-  mv "$asset" bazelisk; \
-  chmod +x bazelisk
+RUN install-image-tool bazelisk
 
 USER circleci
 WORKDIR /home/circleci/

--- a/root/Makefile
+++ b/root/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=root
-VERSION:=2.6
+VERSION:=2.7
 
 include ../make/docker.mk

--- a/root/scripts/install-image-tool.d/bazelisk
+++ b/root/scripts/install-image-tool.d/bazelisk
@@ -1,0 +1,9 @@
+# shellcheck shell=bash
+
+version="${BAZELISK_VERSION:-v1.29.0}"
+arch="$(debian_arch)"
+asset="bazelisk-linux-${arch}"
+base_url="https://github.com/bazelbuild/bazelisk/releases/download/${version}"
+
+download "$base_url/$asset" "$asset"
+install_binary "$asset" bazelisk

--- a/root/scripts/install-image-tool.d/go
+++ b/root/scripts/install-image-tool.d/go
@@ -1,0 +1,10 @@
+# shellcheck shell=bash
+
+version="${GO_VERSION:-1.26.2}"
+arch="$(debian_arch)"
+asset="go${version}.linux-${arch}.tar.gz"
+base_url="https://go.dev/dl"
+
+download "$base_url/$asset" "$asset"
+
+tar -C /usr/local -xf "$asset"

--- a/root/scripts/install-image-tool.d/ruby
+++ b/root/scripts/install-image-tool.d/ruby
@@ -1,0 +1,19 @@
+# shellcheck shell=bash
+
+version="${RUBY_VERSION:-ruby-4.0.3}"
+ruby_version="${version#ruby-}"
+ruby_series="${ruby_version%.*}"
+asset="${version}.tar.gz"
+base_url="https://cache.ruby-lang.org/pub/ruby/${ruby_series}"
+source_dir="/home/circleci/${version}"
+
+download "$base_url/$asset" "$asset"
+
+tar -C /home/circleci -xzf "$asset"
+(
+  cd "$source_dir" || exit
+  ./configure
+  make
+  make install
+)
+rm -rf "$source_dir"

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -3,101 +3,24 @@ FROM alexfalkowski/root:2.6
 USER root
 WORKDIR /usr/local/bin
 
-# Install dockerize.
 ENV DOCKERIZE_VERSION=v0.9.3
-RUN set -eu; \
-  machine="$(dpkg --print-architecture)"; \
-  asset="dockerize-linux-${machine}-${DOCKERIZE_VERSION}.tar.gz"; \
-  curl -fsSLO "https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/${asset}"; \
-  tar -C . -xzvf "$asset"; \
-  rm -f "$asset"
-
-# Install shellcheck.
 ENV SHELLCHECK_VERSION=v0.10.0
-RUN set -eu; \
-  arch="$(uname -m)"; \
-  case "$arch" in \
-  x86_64|amd64) shellcheck_arch="x86_64" ;; \
-  aarch64|arm64) shellcheck_arch="aarch64" ;; \
-  *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
-  esac; \
-  asset="shellcheck-${SHELLCHECK_VERSION}.linux.${shellcheck_arch}.tar.xz"; \
-  curl -fsSLO "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/${asset}"; \
-  tar -C . -xJf "$asset"; \
-  mv shellcheck-${SHELLCHECK_VERSION}/shellcheck .; \
-  rm -rf "shellcheck-${SHELLCHECK_VERSION}" "$asset"
-
-# Install hadolint.
-RUN set -eu; \
-  arch="$(uname -m)"; \
-  case "$arch" in \
-  x86_64|amd64) hadolint_arch="x86_64" ;; \
-  aarch64|arm64) hadolint_arch="arm64" ;; \
-  *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
-  esac; \
-  asset="hadolint-linux-${hadolint_arch}"; \
-  base_url="https://github.com/hadolint/hadolint/releases/download/v2.14.0"; \
-  curl -fsSLo "$asset" "$base_url/$asset"; \
-  curl -fsSLo "$asset.sha256" "$base_url/$asset.sha256"; \
-  sha256sum -c "$asset.sha256"; \
-  mv "$asset" hadolint; \
-  chmod +x hadolint; \
-  rm -f "$asset.sha256"
-
-# Install buf.
-RUN set -eu; \
-  arch="$(uname -m)"; \
-  case "$arch" in \
-  x86_64|amd64) buf_arch="x86_64" ;; \
-  aarch64|arm64) buf_arch="aarch64" ;; \
-  *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
-  esac; \
-  asset="buf-Linux-${buf_arch}"; \
-  base_url="https://github.com/bufbuild/buf/releases/download/v1.68.4"; \
-  curl -fsSLo "$asset" "$base_url/$asset"; \
-  curl -fsSLo sha256.txt "$base_url/sha256.txt"; \
-  grep "  ${asset}$" sha256.txt | sha256sum -c -; \
-  mv "$asset" buf; \
-  chmod +x buf; \
-  rm -f sha256.txt
-
-# Install trivy.
-RUN set -eu; \
-  version="0.70.0"; \
-  machine="$(dpkg --print-architecture)"; \
-  case "$machine" in \
-  amd64) trivy_arch="64bit" ;; \
-  arm64) trivy_arch="ARM64" ;; \
-  *) echo "unsupported arch: $machine" >&2; exit 1 ;; \
-  esac; \
-  asset="trivy_${version}_Linux-${trivy_arch}.tar.gz"; \
-  base_url="https://github.com/aquasecurity/trivy/releases/download/v${version}"; \
-  curl -fsSLO "$base_url/$asset"; \
-  curl -fsSLO "$base_url/trivy_${version}_checksums.txt"; \
-  grep "  ${asset}$" "trivy_${version}_checksums.txt" | sha256sum -c -; \
-  tar -C . -xzf "$asset" trivy; \
-  rm -f "$asset" "trivy_${version}_checksums.txt"
-
-# Install mkcert.
 ENV MKCERT_VERSION=v1.4.4
-RUN set -eu; \
-  machine="$(dpkg --print-architecture)"; \
-  asset="mkcert-${MKCERT_VERSION}-linux-${machine}"; \
-  curl -fsSLo "$asset" "https://github.com/FiloSottile/mkcert/releases/download/${MKCERT_VERSION}/${asset}"; \
-  mv "$asset" mkcert; \
-  chmod +x mkcert
+ARG HADOLINT_VERSION=v2.14.0
+ARG BUF_VERSION=v1.68.4
+ARG TRIVY_VERSION=0.70.0
+ARG CODECOV_VERSION=v11.2.8
 
-# Install codecov.
-RUN set -eux; \
-  arch="$(uname -m)"; \
-  case "$arch" in \
-  x86_64|amd64) asset="codecovcli_linux" ;; \
-  aarch64|arm64) asset="codecovcli_linux_arm64" ;; \
-  *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
-  esac; \
-  curl -fLsSLo codecovcli \
-  "https://github.com/getsentry/prevent-cli/releases/download/v11.2.8/${asset}"; \
-  chmod +x codecovcli
+COPY scripts/install-image-tool /usr/local/bin/install-image-tool
+COPY ruby/scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
+RUN chmod +x /usr/local/bin/install-image-tool \
+  && install-image-tool dockerize \
+  && install-image-tool shellcheck \
+  && install-image-tool hadolint \
+  && install-image-tool buf \
+  && install-image-tool trivy \
+  && install-image-tool mkcert \
+  && install-image-tool codecov
 
 USER circleci
 WORKDIR /home/circleci/

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=ruby
-VERSION:=2.13
+VERSION:=2.14
 
 include ../make/docker.mk

--- a/ruby/scripts/install-image-tool.d/buf
+++ b/ruby/scripts/install-image-tool.d/buf
@@ -1,0 +1,18 @@
+# shellcheck shell=bash
+
+version="${BUF_VERSION:-v1.68.4}"
+
+case "$(uname -m)" in
+  x86_64 | amd64) arch="x86_64" ;;
+  aarch64 | arm64) arch="aarch64" ;;
+  *) unsupported_arch "$(uname -m)" ;;
+esac
+
+asset="buf-Linux-${arch}"
+base_url="https://github.com/bufbuild/buf/releases/download/${version}"
+
+download "$base_url/$asset" "$asset"
+download "$base_url/sha256.txt" sha256.txt
+verify_checksum_file sha256.txt "$asset"
+
+install_binary "$asset" buf

--- a/ruby/scripts/install-image-tool.d/codecov
+++ b/ruby/scripts/install-image-tool.d/codecov
@@ -1,0 +1,14 @@
+# shellcheck shell=bash
+
+version="${CODECOV_VERSION:-v11.2.8}"
+
+case "$(uname -m)" in
+  x86_64 | amd64) asset="codecovcli_linux" ;;
+  aarch64 | arm64) asset="codecovcli_linux_arm64" ;;
+  *) unsupported_arch "$(uname -m)" ;;
+esac
+
+base_url="https://github.com/getsentry/prevent-cli/releases/download/${version}"
+
+download "$base_url/$asset" codecovcli
+install_binary codecovcli codecovcli

--- a/ruby/scripts/install-image-tool.d/dockerize
+++ b/ruby/scripts/install-image-tool.d/dockerize
@@ -1,0 +1,11 @@
+# shellcheck shell=bash
+
+version="${DOCKERIZE_VERSION:-v0.9.3}"
+arch="$(debian_arch)"
+asset="dockerize-linux-${arch}-${version}.tar.gz"
+base_url="https://github.com/jwilder/dockerize/releases/download/${version}"
+
+download "$base_url/$asset" "$asset"
+
+tar -xzf "$asset"
+install_binary dockerize dockerize

--- a/ruby/scripts/install-image-tool.d/hadolint
+++ b/ruby/scripts/install-image-tool.d/hadolint
@@ -1,0 +1,18 @@
+# shellcheck shell=bash
+
+version="${HADOLINT_VERSION:-v2.14.0}"
+
+case "$(uname -m)" in
+  x86_64 | amd64) arch="x86_64" ;;
+  aarch64 | arm64) arch="arm64" ;;
+  *) unsupported_arch "$(uname -m)" ;;
+esac
+
+asset="hadolint-linux-${arch}"
+base_url="https://github.com/hadolint/hadolint/releases/download/${version}"
+
+download "$base_url/$asset" "$asset"
+download "$base_url/$asset.sha256" "$asset.sha256"
+sha256sum -c "$asset.sha256"
+
+install_binary "$asset" hadolint

--- a/ruby/scripts/install-image-tool.d/mkcert
+++ b/ruby/scripts/install-image-tool.d/mkcert
@@ -1,0 +1,9 @@
+# shellcheck shell=bash
+
+version="${MKCERT_VERSION:-v1.4.4}"
+arch="$(debian_arch)"
+asset="mkcert-${version}-linux-${arch}"
+base_url="https://github.com/FiloSottile/mkcert/releases/download/${version}"
+
+download "$base_url/$asset" "$asset"
+install_binary "$asset" mkcert

--- a/ruby/scripts/install-image-tool.d/shellcheck
+++ b/ruby/scripts/install-image-tool.d/shellcheck
@@ -1,0 +1,17 @@
+# shellcheck shell=bash
+
+version="${SHELLCHECK_VERSION:-v0.10.0}"
+
+case "$(uname -m)" in
+  x86_64 | amd64) arch="x86_64" ;;
+  aarch64 | arm64) arch="aarch64" ;;
+  *) unsupported_arch "$(uname -m)" ;;
+esac
+
+asset="shellcheck-${version}.linux.${arch}.tar.xz"
+base_url="https://github.com/koalaman/shellcheck/releases/download/${version}"
+
+download "$base_url/$asset" "$asset"
+
+tar -xJf "$asset"
+install_binary "shellcheck-${version}/shellcheck" shellcheck

--- a/ruby/scripts/install-image-tool.d/trivy
+++ b/ruby/scripts/install-image-tool.d/trivy
@@ -1,0 +1,20 @@
+# shellcheck shell=bash
+
+version="${TRIVY_VERSION:-0.70.0}"
+
+case "$(debian_arch)" in
+  amd64) arch="64bit" ;;
+  arm64) arch="ARM64" ;;
+  *) unsupported_arch "$(debian_arch)" ;;
+esac
+
+asset="trivy_${version}_Linux-${arch}.tar.gz"
+base_url="https://github.com/aquasecurity/trivy/releases/download/v${version}"
+checksum_file="trivy_${version}_checksums.txt"
+
+download "$base_url/$asset" "$asset"
+download "$base_url/$checksum_file" "$checksum_file"
+verify_checksum_file "$checksum_file" "$asset"
+
+tar -xzf "$asset" trivy
+install_binary trivy trivy

--- a/scripts/install-image-tool
+++ b/scripts/install-image-tool
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" -ne 1 ]]; then
+  echo "usage: install-image-tool <tool>" >&2
+  exit 2
+fi
+
+readonly tool="$1"
+
+case "$tool" in
+  "" | *[!a-zA-Z0-9._-]*)
+    echo "invalid tool: $tool" >&2
+    exit 2
+    ;;
+esac
+
+readonly installer="/usr/local/lib/install-image-tool/$tool"
+
+if [[ ! -f "$installer" ]]; then
+  echo "unknown tool: $tool" >&2
+  exit 2
+fi
+
+tmp_dir="$(mktemp -d)"
+readonly tmp_dir
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+
+trap cleanup EXIT
+
+cd "$tmp_dir"
+
+debian_arch() {
+  dpkg --print-architecture
+}
+
+unsupported_arch() {
+  echo "unsupported arch: $1" >&2
+  exit 1
+}
+
+download() {
+  local url="$1"
+  local output="$2"
+
+  curl -fsSLo "$output" "$url"
+}
+
+verify_digest_file() {
+  local digest_file="$1"
+  local asset="$2"
+
+  echo "$(cat "$digest_file")  $asset" | sha256sum -c -
+}
+
+verify_checksum_file() {
+  local checksum_file="$1"
+  local asset="$2"
+
+  grep "  ${asset}$" "$checksum_file" | sha256sum -c -
+}
+
+install_binary() {
+  local source="$1"
+  local target="$2"
+
+  install -Dm755 "$source" "/usr/local/bin/$target"
+}
+
+# shellcheck source=/dev/null
+. "$installer"

--- a/scripts/lint
+++ b/scripts/lint
@@ -14,4 +14,11 @@ done < <(find . -path ./bin -prune -o -type f -name 'Dockerfile' -print0)
 
 # Shellcheck all scripts
 echo "shellcheck: all scripts"
-shellcheck scripts/lint scripts/clean scripts/compose release/deploy release/package release/version
+shellcheck scripts/lint scripts/clean scripts/compose scripts/install-image-tool \
+  release/deploy release/package release/version \
+  docker/scripts/install-image-tool.d/* \
+  go/scripts/install-image-tool.d/* \
+  k8s/scripts/install-image-tool.d/* \
+  release/scripts/install-image-tool.d/* \
+  root/scripts/install-image-tool.d/* \
+  ruby/scripts/install-image-tool.d/*


### PR DESCRIPTION
## What

- Added a shared `scripts/install-image-tool` runner.
- Moved per-tool install logic into per-image `scripts/install-image-tool.d/*` snippets.
- Simplified Dockerfiles to declare versions and call `install-image-tool`.
- Updated `make/docker.mk` to build from the repo root context so all images can reuse the shared runner.
- Added `.dockerignore` and expanded `scripts/lint` coverage for the new scripts.

## Why

- Reduces repeated architecture, download, checksum, extraction, and install logic in Dockerfiles.
- Keeps Dockerfiles easier to scan while preserving per-image install behavior.
- Makes shell install logic lintable with the existing repo workflow.

## Testing

- `make lint`
- `make -C docker build-docker`
- `make -C release build-docker`
- `make -C k8s build-docker`

Before centralizing the shared runner, I also built `go`, `ruby`, and `root`; I did not rerun those three after the final root-context cleanup.