### PR TITLE
feat(deps): bump image versions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:2.6
+FROM alexfalkowski/root:2.7
 
 USER root
 WORKDIR /usr/local/bin

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=docker
-VERSION:=2.8
+VERSION:=2.9
 
 include ../make/docker.mk

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:2.6
+FROM alexfalkowski/root:2.7
 
 USER root
 WORKDIR /usr/local/bin

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=go
-VERSION:=3.19
+VERSION:=3.20
 
 include ../make/docker.mk

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:2.6
+FROM alexfalkowski/root:2.7
 
 USER root
 WORKDIR /usr/local/bin

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=k8s
-VERSION:=3.14
+VERSION:=3.15
 
 include ../make/docker.mk

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:2.6
+FROM alexfalkowski/root:2.7
 
 USER root
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=release
-VERSION:=7.15
+VERSION:=7.16
 
 include ../make/docker.mk

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:2.6
+FROM alexfalkowski/root:2.7
 
 USER root
 WORKDIR /usr/local/bin

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=ruby
-VERSION:=2.14
+VERSION:=2.15
 
 include ../make/docker.mk


### PR DESCRIPTION
## What

- Update downstream Dockerfiles from `alexfalkowski/root:2.6` to `alexfalkowski/root:2.7`.
- Bump dependent image versions:
  - `docker` to `2.9`
  - `go` to `3.20`
  - `k8s` to `3.15`
  - `release` to `7.16`
  - `ruby` to `2.15`

## Why

- Publishes new image tags for the images that now consume the updated `root` base image.
- Keeps image version metadata aligned with the base image change.

## Testing

- `make lint`