### PR TITLE
docs(readme): update installer snippet guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,10 @@ Use the shared `coding-standards` skill from `bin/skills/coding-standards` for c
 ## Layout
 
 - Image directories: `docker/`, `go/`, `k8s/`, `release/`, `root/`, `ruby/`.
-- Each image directory has `Dockerfile`, `Makefile`, `.hadolint.yaml`, and usually `scripts/install-image-tool.d/`.
+- Each image directory has `Dockerfile`, `Makefile`, `.hadolint.yaml`, and may have `scripts/install-image-tool.d/`.
 - Shared image build targets live in `make/docker.mk`.
 - Shared scripts live in `scripts/`; `scripts/install-image-tool` is the common runner used by Dockerfiles.
+- Shared install snippets used by multiple images live in `scripts/install-image-tool.d/`.
 - CircleCI path-filtering and workflows live under `.circleci/`.
 
 ## Commands
@@ -51,7 +52,7 @@ Use the shared `coding-standards` skill from `bin/skills/coding-standards` for c
 - Image `Makefile`s set `IMAGE` and `VERSION`, then include `../make/docker.mk`.
 - `make/docker.mk` intentionally builds from the repo root context with `docker build -f Dockerfile ... ..` so Dockerfiles can copy shared files such as `scripts/install-image-tool`.
 - Keep `.dockerignore` current when adding large or sensitive top-level paths.
-- Dockerfiles should call `install-image-tool`; put image-specific download/checksum/extract logic in that image's `scripts/install-image-tool.d/` directory.
+- Dockerfiles should call `install-image-tool`; put reusable download/checksum/extract logic in `scripts/install-image-tool.d/` and image-specific logic in that image's `scripts/install-image-tool.d/` directory.
 - If changing hadolint suppressions, update the image directory's `.hadolint.yaml`; there is no top-level hadolint config.
 
 ## Release Image

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Each top-level directory is an image (or runtime config used by the compose stac
     - `Dockerfile`
     - `Makefile` declaring `IMAGE` and `VERSION`
     - `.hadolint.yaml` (image-specific hadolint rule suppressions)
-    - `scripts/install-image-tool.d/` snippets for image-specific tool installs
+    - `scripts/install-image-tool.d/` snippets for image-specific tool installs, when needed
 - Local dependency stack:
   - `compose.yml`
   - `grafana/`, `otelcol/`, `prometheus/`, `status/` (config mounted into compose services)
@@ -28,6 +28,7 @@ Each top-level directory is an image (or runtime config used by the compose stac
   - `scripts/compose` (prefers `podman compose`, falls back to `docker compose`)
   - `scripts/clean` (prunes unused images)
   - `scripts/install-image-tool` (shared image build-time installer runner)
+  - `scripts/install-image-tool.d/` (shared install snippets used by multiple images)
   - `scripts/lint` (runs hadolint + shellcheck)
 
 ## Prerequisites
@@ -70,6 +71,7 @@ What it does (see `scripts/lint`):
 - Runs `shellcheck` against:
   - `scripts/lint`, `scripts/clean`, `scripts/compose`, `scripts/install-image-tool`
   - `release/deploy`, `release/package`, `release/version`
+  - shared `scripts/install-image-tool.d/*` snippets
   - per-image `scripts/install-image-tool.d/*` snippets
 
 ### Build images locally


### PR DESCRIPTION
## What

- Updated README layout and lint docs to include shared installer snippets in `scripts/install-image-tool.d/`.
- Updated AGENTS guidance to distinguish reusable shared installer logic from image-specific installer logic.

## Why

- The repository now has shared install snippets used by multiple images.
- The docs should point future changes toward the shared location when installer logic is reusable.

## Testing

- Not run; documentation-only change.