### PR TITLE
feat(scripts): pass installer versions as arguments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Use the shared `coding-standards` skill from `bin/skills/coding-standards` for c
 - Image directories: `docker/`, `go/`, `k8s/`, `release/`, `root/`, `ruby/`.
 - Each image directory has `Dockerfile`, `Makefile`, `.hadolint.yaml`, and may have `scripts/install-image-tool.d/`.
 - Shared image build targets live in `make/docker.mk`.
-- Shared scripts live in `scripts/`; `scripts/install-image-tool` is the common runner used by Dockerfiles.
+- Shared scripts live in `scripts/`; `scripts/install-image-tool` is the common runner used by Dockerfiles as `install-image-tool <tool> [version]`.
 - Shared install snippets used by multiple images live in `scripts/install-image-tool.d/`.
 - CircleCI path-filtering and workflows live under `.circleci/`.
 
@@ -52,7 +52,7 @@ Use the shared `coding-standards` skill from `bin/skills/coding-standards` for c
 - Image `Makefile`s set `IMAGE` and `VERSION`, then include `../make/docker.mk`.
 - `make/docker.mk` intentionally builds from the repo root context with `docker build -f Dockerfile ... ..` so Dockerfiles can copy shared files such as `scripts/install-image-tool`.
 - Keep `.dockerignore` current when adding large or sensitive top-level paths.
-- Dockerfiles should call `install-image-tool`; put reusable download/checksum/extract logic in `scripts/install-image-tool.d/` and image-specific logic in that image's `scripts/install-image-tool.d/` directory.
+- Dockerfiles should call `install-image-tool <tool> <version>`; put reusable download/checksum/extract logic in `scripts/install-image-tool.d/` and image-specific logic in that image's `scripts/install-image-tool.d/` directory.
 - If changing hadolint suppressions, update the image directory's `.hadolint.yaml`; there is no top-level hadolint config.
 
 ## Release Image

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Each top-level directory is an image (or runtime config used by the compose stac
 - Helper scripts:
   - `scripts/compose` (prefers `podman compose`, falls back to `docker compose`)
   - `scripts/clean` (prunes unused images)
-  - `scripts/install-image-tool` (shared image build-time installer runner)
+  - `scripts/install-image-tool` (shared image build-time installer runner: `install-image-tool <tool> [version]`)
   - `scripts/install-image-tool.d/` (shared install snippets used by multiple images)
   - `scripts/lint` (runs hadolint + shellcheck)
 
@@ -78,6 +78,7 @@ What it does (see `scripts/lint`):
 
 Each image directory has a `Makefile` that sets `IMAGE` and `VERSION` and then includes `../make/docker.mk`.
 The shared build targets run from the image directory but use the repository root as Docker build context so Dockerfiles can copy the shared installer script.
+Dockerfiles pass tool versions directly to `install-image-tool <tool> [version]`; installer snippets keep defaults for manual use.
 
 Build an image locally:
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,12 +3,9 @@ FROM alexfalkowski/root:2.7
 USER root
 WORKDIR /usr/local/bin
 
-ARG HADOLINT_VERSION=v2.14.0
-ENV SHELLCHECK_VERSION=v0.11.0
-
 COPY scripts/install-image-tool /usr/local/bin/install-image-tool
 COPY scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
 COPY docker/scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
 RUN chmod +x /usr/local/bin/install-image-tool \
-  && install-image-tool hadolint \
-  && install-image-tool shellcheck
+  && install-image-tool hadolint v2.14.0 \
+  && install-image-tool shellcheck v0.11.0

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=docker
-VERSION:=2.9
+VERSION:=2.10
 
 include ../make/docker.mk

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -3,27 +3,20 @@ FROM alexfalkowski/root:2.7
 USER root
 WORKDIR /usr/local/bin
 
-ENV DOCKERIZE_VERSION=v0.9.3
-ENV SHELLCHECK_VERSION=v0.11.0
-ENV MKCERT_VERSION=v1.4.4
 ENV GO_LINT_VERSION=2.11.4
-ARG HADOLINT_VERSION=v2.14.0
-ARG BUF_VERSION=v1.69.0
-ARG TRIVY_VERSION=0.70.0
-ARG CODECOV_VERSION=v11.2.8
 
 COPY scripts/install-image-tool /usr/local/bin/install-image-tool
 COPY scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
 COPY go/scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
 RUN chmod +x /usr/local/bin/install-image-tool \
-  && install-image-tool dockerize \
-  && install-image-tool shellcheck \
-  && install-image-tool hadolint \
-  && install-image-tool buf \
-  && install-image-tool trivy \
-  && install-image-tool mkcert \
-  && install-image-tool codecov \
-  && install-image-tool golangci-lint
+  && install-image-tool dockerize v0.9.3 \
+  && install-image-tool shellcheck v0.11.0 \
+  && install-image-tool hadolint v2.14.0 \
+  && install-image-tool buf v1.69.0 \
+  && install-image-tool trivy 0.70.0 \
+  && install-image-tool mkcert v1.4.4 \
+  && install-image-tool codecov v11.2.8 \
+  && install-image-tool golangci-lint "$GO_LINT_VERSION"
 
 USER circleci
 WORKDIR /home/circleci/

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=go
-VERSION:=3.21
+VERSION:=3.22
 
 include ../make/docker.mk

--- a/go/scripts/install-image-tool.d/golangci-lint
+++ b/go/scripts/install-image-tool.d/golangci-lint
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${GO_LINT_VERSION:-2.11.4}"
+version="${1:-2.11.4}"
 arch="$(debian_arch)"
 asset="golangci-lint-${version}-linux-${arch}.tar.gz"
 base_url="https://github.com/golangci/golangci-lint/releases/download/v${version}"

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -3,22 +3,15 @@ FROM alexfalkowski/root:2.7
 USER root
 WORKDIR /usr/local/bin
 
-ARG KUBECTL_VERSION=1.36.0
-ARG VEGETA_VERSION=12.12.0
-ARG HELM_VERSION=v4.1.1
-ARG DOCTL_VERSION=1.155.0
-ARG KUBESCAPE_VERSION=4.0.5
-ARG PULUMI_VERSION=3.232.0
-
 COPY scripts/install-image-tool /usr/local/bin/install-image-tool
 COPY k8s/scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
 RUN chmod +x /usr/local/bin/install-image-tool \
-  && install-image-tool kubectl \
-  && install-image-tool vegeta \
-  && install-image-tool helm \
-  && install-image-tool doctl \
-  && install-image-tool kubescape \
-  && install-image-tool pulumi
+  && install-image-tool kubectl 1.36.0 \
+  && install-image-tool vegeta 12.12.0 \
+  && install-image-tool helm v4.1.1 \
+  && install-image-tool doctl 1.155.0 \
+  && install-image-tool kubescape 4.0.5 \
+  && install-image-tool pulumi 3.232.0
 
 USER circleci
 WORKDIR /home/circleci/

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=k8s
-VERSION:=3.15
+VERSION:=3.16
 
 include ../make/docker.mk

--- a/k8s/scripts/install-image-tool.d/doctl
+++ b/k8s/scripts/install-image-tool.d/doctl
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${DOCTL_VERSION:-1.155.0}"
+version="${1:-1.155.0}"
 arch="$(debian_arch)"
 asset="doctl-${version}-linux-${arch}.tar.gz"
 base_url="https://github.com/digitalocean/doctl/releases/download/v${version}"

--- a/k8s/scripts/install-image-tool.d/helm
+++ b/k8s/scripts/install-image-tool.d/helm
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${HELM_VERSION:-v4.1.1}"
+version="${1:-v4.1.1}"
 arch="$(debian_arch)"
 asset="helm-${version}-linux-${arch}.tar.gz"
 base_url="https://get.helm.sh"

--- a/k8s/scripts/install-image-tool.d/kubectl
+++ b/k8s/scripts/install-image-tool.d/kubectl
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${KUBECTL_VERSION:-1.36.0}"
+version="${1:-1.36.0}"
 arch="$(debian_arch)"
 base_url="https://dl.k8s.io/release/v${version}/bin/linux/${arch}"
 

--- a/k8s/scripts/install-image-tool.d/kubescape
+++ b/k8s/scripts/install-image-tool.d/kubescape
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${KUBESCAPE_VERSION:-4.0.5}"
+version="${1:-4.0.5}"
 arch="$(debian_arch)"
 asset="kubescape_${version}_linux_${arch}.tar.gz"
 base_url="https://github.com/kubescape/kubescape/releases/download/v${version}"

--- a/k8s/scripts/install-image-tool.d/pulumi
+++ b/k8s/scripts/install-image-tool.d/pulumi
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${PULUMI_VERSION:-3.232.0}"
+version="${1:-3.232.0}"
 
 case "$(debian_arch)" in
   amd64) arch="x64" ;;

--- a/k8s/scripts/install-image-tool.d/vegeta
+++ b/k8s/scripts/install-image-tool.d/vegeta
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${VEGETA_VERSION:-12.12.0}"
+version="${1:-12.12.0}"
 arch="$(debian_arch)"
 asset="vegeta_${version}_linux_${arch}.tar.gz"
 base_url="https://github.com/tsenart/vegeta/releases/download/v${version}"

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -2,16 +2,12 @@ FROM alexfalkowski/root:2.7
 
 USER root
 
-ARG GORELEASER_VERSION=2.15.4
-ARG UPLIFT_VERSION=2.26.0
-ARG GH_VERSION=2.92.0
-
 COPY scripts/install-image-tool /usr/local/bin/install-image-tool
 COPY release/scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
 RUN chmod +x /usr/local/bin/install-image-tool \
-  && install-image-tool goreleaser \
-  && install-image-tool uplift \
-  && install-image-tool gh
+  && install-image-tool goreleaser 2.15.4 \
+  && install-image-tool uplift 2.26.0 \
+  && install-image-tool gh 2.92.0
 
 # Add uplift config.
 RUN mkdir /etc/uplift

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=release
-VERSION:=7.16
+VERSION:=7.17
 
 include ../make/docker.mk

--- a/release/scripts/install-image-tool.d/gh
+++ b/release/scripts/install-image-tool.d/gh
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${GH_VERSION:-2.92.0}"
+version="${1:-2.92.0}"
 arch="$(debian_arch)"
 asset="gh_${version}_linux_${arch}.deb"
 base_url="https://github.com/cli/cli/releases/download/v${version}"

--- a/release/scripts/install-image-tool.d/goreleaser
+++ b/release/scripts/install-image-tool.d/goreleaser
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${GORELEASER_VERSION:-2.15.4}"
+version="${1:-2.15.4}"
 arch="$(debian_arch)"
 asset="goreleaser_${version}_${arch}.deb"
 base_url="https://github.com/goreleaser/goreleaser/releases/download/v${version}"

--- a/release/scripts/install-image-tool.d/uplift
+++ b/release/scripts/install-image-tool.d/uplift
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${UPLIFT_VERSION:-2.26.0}"
+version="${1:-2.26.0}"
 arch="$(debian_arch)"
 asset="uplift_${version}_${arch}.deb"
 base_url="https://github.com/gembaadvantage/uplift/releases/download/v${version}"

--- a/root/Dockerfile
+++ b/root/Dockerfile
@@ -12,21 +12,20 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 ENV GO_VERSION=1.26.2
 ENV RUBY_VERSION=ruby-4.0.3
-ARG BAZELISK_VERSION=v1.29.0
 
 WORKDIR /usr/local/bin
 COPY scripts/install-image-tool /usr/local/bin/install-image-tool
 COPY root/scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
 RUN chmod +x /usr/local/bin/install-image-tool \
-  && install-image-tool go \
-  && install-image-tool ruby
+  && install-image-tool go "$GO_VERSION" \
+  && install-image-tool ruby "$RUBY_VERSION"
 
 # Install gems, https://rubygems.org/gems/rubygems-update.
 RUN gem update --system 4.0.8 \
   && gem install bundler -v 4.0.8 \
   && gem install executable-hooks -v 1.7.1
 
-RUN install-image-tool bazelisk
+RUN install-image-tool bazelisk v1.29.0
 
 USER circleci
 WORKDIR /home/circleci/

--- a/root/Makefile
+++ b/root/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=root
-VERSION:=2.7
+VERSION:=2.8
 
 include ../make/docker.mk

--- a/root/scripts/install-image-tool.d/bazelisk
+++ b/root/scripts/install-image-tool.d/bazelisk
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${BAZELISK_VERSION:-v1.29.0}"
+version="${1:-v1.29.0}"
 arch="$(debian_arch)"
 asset="bazelisk-linux-${arch}"
 base_url="https://github.com/bazelbuild/bazelisk/releases/download/${version}"

--- a/root/scripts/install-image-tool.d/go
+++ b/root/scripts/install-image-tool.d/go
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${GO_VERSION:-1.26.2}"
+version="${1:-1.26.2}"
 arch="$(debian_arch)"
 asset="go${version}.linux-${arch}.tar.gz"
 base_url="https://go.dev/dl"

--- a/root/scripts/install-image-tool.d/ruby
+++ b/root/scripts/install-image-tool.d/ruby
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${RUBY_VERSION:-ruby-4.0.3}"
+version="${1:-ruby-4.0.3}"
 ruby_version="${version#ruby-}"
 ruby_series="${ruby_version%.*}"
 asset="${version}.tar.gz"

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -3,25 +3,17 @@ FROM alexfalkowski/root:2.7
 USER root
 WORKDIR /usr/local/bin
 
-ENV DOCKERIZE_VERSION=v0.9.3
-ENV SHELLCHECK_VERSION=v0.11.0
-ENV MKCERT_VERSION=v1.4.4
-ARG HADOLINT_VERSION=v2.14.0
-ARG BUF_VERSION=v1.69.0
-ARG TRIVY_VERSION=0.70.0
-ARG CODECOV_VERSION=v11.2.8
-
 COPY scripts/install-image-tool /usr/local/bin/install-image-tool
 COPY scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
 COPY ruby/scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
 RUN chmod +x /usr/local/bin/install-image-tool \
-  && install-image-tool dockerize \
-  && install-image-tool shellcheck \
-  && install-image-tool hadolint \
-  && install-image-tool buf \
-  && install-image-tool trivy \
-  && install-image-tool mkcert \
-  && install-image-tool codecov
+  && install-image-tool dockerize v0.9.3 \
+  && install-image-tool shellcheck v0.11.0 \
+  && install-image-tool hadolint v2.14.0 \
+  && install-image-tool buf v1.69.0 \
+  && install-image-tool trivy 0.70.0 \
+  && install-image-tool mkcert v1.4.4 \
+  && install-image-tool codecov v11.2.8
 
 USER circleci
 WORKDIR /home/circleci/

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=ruby
-VERSION:=2.16
+VERSION:=2.17
 
 include ../make/docker.mk

--- a/scripts/install-image-tool
+++ b/scripts/install-image-tool
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-if [[ "$#" -ne 1 ]]; then
-  echo "usage: install-image-tool <tool>" >&2
+if [[ "$#" -lt 1 || "$#" -gt 2 ]]; then
+  echo "usage: install-image-tool <tool> [version]" >&2
   exit 2
 fi
 
@@ -72,4 +72,4 @@ install_binary() {
 }
 
 # shellcheck source=/dev/null
-. "$installer"
+. "$installer" "${2:-}"

--- a/scripts/install-image-tool.d/buf
+++ b/scripts/install-image-tool.d/buf
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${BUF_VERSION:-v1.69.0}"
+version="${1:-v1.69.0}"
 
 case "$(uname -m)" in
   x86_64 | amd64) arch="x86_64" ;;

--- a/scripts/install-image-tool.d/codecov
+++ b/scripts/install-image-tool.d/codecov
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${CODECOV_VERSION:-v11.2.8}"
+version="${1:-v11.2.8}"
 
 case "$(uname -m)" in
   x86_64 | amd64) asset="codecovcli_linux" ;;

--- a/scripts/install-image-tool.d/dockerize
+++ b/scripts/install-image-tool.d/dockerize
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${DOCKERIZE_VERSION:-v0.9.3}"
+version="${1:-v0.9.3}"
 arch="$(debian_arch)"
 asset="dockerize-linux-${arch}-${version}.tar.gz"
 base_url="https://github.com/jwilder/dockerize/releases/download/${version}"

--- a/scripts/install-image-tool.d/hadolint
+++ b/scripts/install-image-tool.d/hadolint
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${HADOLINT_VERSION:-v2.14.0}"
+version="${1:-v2.14.0}"
 
 case "$(uname -m)" in
   x86_64 | amd64) arch="x86_64" ;;

--- a/scripts/install-image-tool.d/mkcert
+++ b/scripts/install-image-tool.d/mkcert
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${MKCERT_VERSION:-v1.4.4}"
+version="${1:-v1.4.4}"
 arch="$(debian_arch)"
 asset="mkcert-${version}-linux-${arch}"
 base_url="https://github.com/FiloSottile/mkcert/releases/download/${version}"

--- a/scripts/install-image-tool.d/shellcheck
+++ b/scripts/install-image-tool.d/shellcheck
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${SHELLCHECK_VERSION:-v0.11.0}"
+version="${1:-v0.11.0}"
 
 case "$(uname -m)" in
   x86_64 | amd64) arch="x86_64" ;;

--- a/scripts/install-image-tool.d/trivy
+++ b/scripts/install-image-tool.d/trivy
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${TRIVY_VERSION:-0.70.0}"
+version="${1:-0.70.0}"
 
 case "$(debian_arch)" in
   amd64) arch="64bit" ;;


### PR DESCRIPTION
## What

- Updated `install-image-tool` to accept an optional version argument.
- Changed installer snippets to read the version from the positional argument while keeping their default fallback versions.
- Updated Dockerfiles to pass installer versions directly at call sites, keeping shared values like `GO_LINT_VERSION`, `GO_VERSION`, and `RUBY_VERSION` where they are reused.
- Bumped changed image Makefile versions for `docker`, `go`, `k8s`, `release`, `root`, and `ruby`.
- Updated README and AGENTS guidance for the new installer call format.

## Why

- Makes installer version inputs explicit at each Dockerfile call site.
- Avoids one-off `ARG` and `ENV` declarations that only existed to feed installer scripts.
- Keeps documented image versions in sync with changed image contents.

## Testing

- `make dep` was attempted, but this repo has no `dep` target.
- `make lint` passed.