### PR TITLE
feat(deps): update images to root 2.8

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:2.7
+FROM alexfalkowski/root:2.8
 
 USER root
 WORKDIR /usr/local/bin

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=docker
-VERSION:=2.10
+VERSION:=2.11
 
 include ../make/docker.mk

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:2.7
+FROM alexfalkowski/root:2.8
 
 USER root
 WORKDIR /usr/local/bin

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=go
-VERSION:=3.22
+VERSION:=3.23
 
 include ../make/docker.mk

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:2.7
+FROM alexfalkowski/root:2.8
 
 USER root
 WORKDIR /usr/local/bin

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=k8s
-VERSION:=3.16
+VERSION:=3.17
 
 include ../make/docker.mk

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:2.7
+FROM alexfalkowski/root:2.8
 
 USER root
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=release
-VERSION:=7.17
+VERSION:=7.18
 
 include ../make/docker.mk

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:2.7
+FROM alexfalkowski/root:2.8
 
 USER root
 WORKDIR /usr/local/bin

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=ruby
-VERSION:=2.17
+VERSION:=2.18
 
 include ../make/docker.mk


### PR DESCRIPTION
## What

- Updated downstream image Dockerfiles to use `alexfalkowski/root:2.8`.
- Bumped the corresponding image versions for `docker`, `go`, `k8s`, `release`, and `ruby`.

## Why

- Keeps dependent images aligned with the latest `root` image version.
- Publishes new downstream image tags for the base image update.

## Testing

- `make lint` passed.