### PR TITLE
feat(root): move root image to debian trixie

### DIFF
--- a/root/Dockerfile
+++ b/root/Dockerfile
@@ -1,14 +1,35 @@
-FROM cimg/base:2026.04-24.04
+FROM debian:trixie-slim
 
 USER root
 
 # Install packages.
 RUN apt-get update && apt-get install --no-install-recommends -y \
+  bash \
+  build-essential \
+  ca-certificates \
   clang \
+  curl \
+  git \
   libc6-dev \
+  libffi-dev \
+  libgdbm-dev \
+  libncurses-dev \
   libpq-dev \
+  libreadline-dev \
+  libssl-dev \
   libyaml-dev \
+  make \
+  openssh-client \
+  pkg-config \
+  sudo \
+  xz-utils \
+  zlib1g-dev \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN groupadd --gid 3434 circleci \
+  && useradd --uid 3434 --gid circleci --create-home --shell /bin/bash circleci \
+  && echo "circleci ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/circleci \
+  && chmod 0440 /etc/sudoers.d/circleci
 
 ENV GO_VERSION=1.26.2
 ENV RUBY_VERSION=ruby-4.0.3
@@ -21,11 +42,9 @@ RUN chmod +x /usr/local/bin/install-image-tool \
   && install-image-tool ruby "$RUBY_VERSION"
 
 # Install gems, https://rubygems.org/gems/rubygems-update.
-RUN gem update --system 4.0.8 \
-  && gem install bundler -v 4.0.8 \
+RUN gem update --system 4.0.11 \
+  && gem install bundler -v 4.0.11 \
   && gem install executable-hooks -v 1.7.1
-
-RUN install-image-tool bazelisk v1.29.0
 
 USER circleci
 WORKDIR /home/circleci/
@@ -41,8 +60,3 @@ RUN mkdir -p go/bin
 RUN echo "$GO_VERSION" > .go-version
 ENV GOPATH=/home/circleci/go
 ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
-
-# Setup bazelisk.
-ENV USE_BAZEL_VERSION=9.0.0
-RUN echo "$USE_BAZEL_VERSION" > .bazelversion
-RUN bazelisk version

--- a/root/Makefile
+++ b/root/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=root
-VERSION:=2.8
+VERSION:=3.0
 
 include ../make/docker.mk

--- a/root/scripts/install-image-tool.d/bazelisk
+++ b/root/scripts/install-image-tool.d/bazelisk
@@ -1,9 +1,0 @@
-# shellcheck shell=bash
-
-version="${1:-v1.29.0}"
-arch="$(debian_arch)"
-asset="bazelisk-linux-${arch}"
-base_url="https://github.com/bazelbuild/bazelisk/releases/download/${version}"
-
-download "$base_url/$asset" "$asset"
-install_binary "$asset" bazelisk


### PR DESCRIPTION
**What**
- Switches `root` from `cimg/base:2026.04-24.04` to `debian:trixie-slim`.
- Explicitly installs the packages previously inherited from the CircleCI base.
- Recreates the `circleci` user and passwordless sudo setup.
- Updates RubyGems and Bundler to `4.0.11`.
- Remove Bazel.
- Bumps the `root` image version to `3.0`.

**Why**
- Reduces the inherited base-image footprint and vulnerability surface.
- Makes root image dependencies explicit instead of relying on CircleCI base image contents.
- Produces a smaller final root image: `root:3.0` is ~1.25 GB vs `root:2.8` at ~2.18 GB locally.

**Testing**
- `make -C root lint-docker`
- `make -C root build-docker`
- `docker run --rm alexfalkowski/root:3.0 ...` smoke-tested `id`, `sudo`, `PATH`, `GOPATH`, Go, Ruby, RubyGems, Bundler, OpenSSL, zlib, and psych.
- Pulled and inspected `alexfalkowski/root:2.8` to compare image size against the new local `root:3.0`.