### PR TITLE
feat(deps): bump root image dependents

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:2.8
+FROM alexfalkowski/root:3.0
 
 USER root
 WORKDIR /usr/local/bin

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=docker
-VERSION:=2.11
+VERSION:=3.0
 
 include ../make/docker.mk

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:2.8
+FROM alexfalkowski/root:3.0
 
 USER root
 WORKDIR /usr/local/bin

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=go
-VERSION:=3.26
+VERSION:=4.0
 
 include ../make/docker.mk

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:2.8
+FROM alexfalkowski/root:3.0
 
 USER root
 WORKDIR /usr/local/bin

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=k8s
-VERSION:=3.21
+VERSION:=4.0
 
 include ../make/docker.mk

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:2.8
+FROM alexfalkowski/root:3.0
 
 USER root
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=release
-VERSION:=7.19
+VERSION:=8.0
 
 include ../make/docker.mk

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:2.8
+FROM alexfalkowski/root:3.0
 
 USER root
 WORKDIR /usr/local/bin

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=ruby
-VERSION:=2.19
+VERSION:=3.0
 
 include ../make/docker.mk


### PR DESCRIPTION
## What
- Updates `docker`, `go`, `k8s`, `release`, and `ruby` images to use `alexfalkowski/root:3.0`.
- Bumps each dependent image to the next major version:
  - `docker`: `3.0`
  - `go`: `4.0`
  - `k8s`: `4.0`
  - `release`: `8.0`
  - `ruby`: `3.0`

## Why
- Moves all downstream images onto the new root image baseline.
- Uses major version bumps because the root base image changed from `2.8` to `3.0`.

## Testing
- `make -C docker lint-docker`
- `make -C go lint-docker`
- `make -C k8s lint-docker`
- `make -C release lint-docker`
- `make -C ruby lint-docker`
- Confirmed no remaining `alexfalkowski/root:2.8` references in dependent image directories.