### PR TITLE
feat(root): add docker tooling

### DIFF
--- a/root/Dockerfile
+++ b/root/Dockerfile
@@ -9,6 +9,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   ca-certificates \
   clang \
   curl \
+  docker-buildx \
+  docker-cli \
+  docker-compose \
+  docker.io \
   git \
   libc6-dev \
   libffi-dev \

--- a/root/Makefile
+++ b/root/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=root
-VERSION:=3.0
+VERSION:=3.1
 
 include ../make/docker.mk


### PR DESCRIPTION
## What

- Bump `root` image version to `3.1`.
- Add Docker CLI, daemon, Compose, and Buildx packages to the Debian Trixie root image.

## Why

- Restore the Docker tooling previously inherited from `cimg/base`.
- Keep downstream image builds compatible with workflows that call `docker`, `dockerd`, `docker compose`, or `docker buildx`.

## Testing

- Ran `make -C root lint-docker`.
- Smoke checked package installation in `debian:trixie-slim` and verified Docker tooling is available.