### PR TITLE
feat(deps): use root 3.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.0
+FROM alexfalkowski/root:3.1
 
 USER root
 WORKDIR /usr/local/bin

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=docker
-VERSION:=3.0
+VERSION:=3.1
 
 include ../make/docker.mk

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.0
+FROM alexfalkowski/root:3.1
 
 USER root
 WORKDIR /usr/local/bin

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=go
-VERSION:=4.0
+VERSION:=4.1
 
 include ../make/docker.mk

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.0
+FROM alexfalkowski/root:3.1
 
 USER root
 WORKDIR /usr/local/bin

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=k8s
-VERSION:=4.0
+VERSION:=4.1
 
 include ../make/docker.mk

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.0
+FROM alexfalkowski/root:3.1
 
 USER root
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=release
-VERSION:=8.0
+VERSION:=8.1
 
 include ../make/docker.mk

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.0
+FROM alexfalkowski/root:3.1
 
 USER root
 WORKDIR /usr/local/bin

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=ruby
-VERSION:=3.0
+VERSION:=3.1
 
 include ../make/docker.mk


### PR DESCRIPTION
## What

- Update child images to use `alexfalkowski/root:3.1`.
- Bump child image versions by one minor release:
  - `docker` `3.0` to `3.1`
  - `go` `4.0` to `4.1`
  - `k8s` `4.0` to `4.1`
  - `release` `8.0` to `8.1`
  - `ruby` `3.0` to `3.1`

## Why

- Pick up the updated root image with Debian Trixie and restored Docker tooling.
- Publish new child image tags for the root dependency change.

## Testing

- Ran `make -C docker lint-docker`.
- Ran `make -C go lint-docker`.
- Ran `make -C k8s lint-docker`.
- Ran `make -C release lint-docker`.
- Ran `make -C ruby lint-docker`.