### PR TITLE
feat(root): add netcat

### DIFF
--- a/root/Dockerfile
+++ b/root/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   libssl-dev \
   libyaml-dev \
   make \
+  netcat-openbsd \
   openssh-client \
   pkg-config \
   sudo \

--- a/root/Makefile
+++ b/root/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=root
-VERSION:=3.1
+VERSION:=3.2
 
 include ../make/docker.mk


### PR DESCRIPTION
## What

- Add `netcat-openbsd` to the root image.
- Bump the root image version from `3.1` to `3.2`.

## Why

- Provide the `nc` command in the shared root image for scripts and connectivity checks.
- Publish a new root image tag for the added tool.

## Testing

- Ran `make -C root lint-docker`.
- Smoke checked `netcat-openbsd` in `debian:trixie-slim` and confirmed `/usr/bin/nc` is available.