### PR TITLE
feat(deps): use root 3.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.1
+FROM alexfalkowski/root:3.2
 
 USER root
 WORKDIR /usr/local/bin

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=docker
-VERSION:=3.1
+VERSION:=3.2
 
 include ../make/docker.mk

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.1
+FROM alexfalkowski/root:3.2
 
 USER root
 WORKDIR /usr/local/bin

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=go
-VERSION:=4.1
+VERSION:=4.2
 
 include ../make/docker.mk

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.1
+FROM alexfalkowski/root:3.2
 
 USER root
 WORKDIR /usr/local/bin

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=k8s
-VERSION:=4.1
+VERSION:=4.2
 
 include ../make/docker.mk

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.1
+FROM alexfalkowski/root:3.2
 
 USER root
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=release
-VERSION:=8.1
+VERSION:=8.2
 
 include ../make/docker.mk

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.1
+FROM alexfalkowski/root:3.2
 
 USER root
 WORKDIR /usr/local/bin

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=ruby
-VERSION:=3.1
+VERSION:=3.2
 
 include ../make/docker.mk


### PR DESCRIPTION
## What

- Update child images to use `alexfalkowski/root:3.2`.
- Bump child image versions by one minor release:
  - `docker` `3.1` to `3.2`
  - `go` `4.1` to `4.2`
  - `k8s` `4.1` to `4.2`
  - `release` `8.1` to `8.2`
  - `ruby` `3.1` to `3.2`

## Why

- Pick up the root image that includes `nc`.
- Publish new child image tags for the root dependency update.

## Testing

- Ran `make -C docker lint-docker`.
- Ran `make -C go lint-docker`.
- Ran `make -C k8s lint-docker`.
- Ran `make -C release lint-docker`.
- Ran `make -C ruby lint-docker`.