### PR TITLE
feat(deps): use root 3.3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.2
+FROM alexfalkowski/root:3.3
 
 USER root
 WORKDIR /usr/local/bin

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=docker
-VERSION:=3.2
+VERSION:=3.3
 
 include ../make/docker.mk

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.2
+FROM alexfalkowski/root:3.3
 
 USER root
 WORKDIR /usr/local/bin

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=go
-VERSION:=4.2
+VERSION:=4.3
 
 include ../make/docker.mk

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.2
+FROM alexfalkowski/root:3.3
 
 USER root
 WORKDIR /usr/local/bin

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=k8s
-VERSION:=4.2
+VERSION:=4.3
 
 include ../make/docker.mk

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.2
+FROM alexfalkowski/root:3.3
 
 USER root
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=release
-VERSION:=8.2
+VERSION:=8.3
 
 include ../make/docker.mk

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.2
+FROM alexfalkowski/root:3.3
 
 USER root
 WORKDIR /usr/local/bin

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=ruby
-VERSION:=3.2
+VERSION:=3.3
 
 include ../make/docker.mk


### PR DESCRIPTION
## What

- Update child images to use `alexfalkowski/root:3.3`.
- Bump child image versions by one minor release:
  - `docker` `3.2` to `3.3`
  - `go` `4.2` to `4.3`
  - `k8s` `4.2` to `4.3`
  - `release` `8.2` to `8.3`
  - `ruby` `3.2` to `3.3`

## Why

- Pick up the root image that uses the official Ruby `4.0.3` Trixie base.
- Publish new child image tags for the root dependency update.

## Testing

- Ran `make -C docker lint-docker`.
- Ran `make -C go lint-docker`.
- Ran `make -C k8s lint-docker`.
- Ran `make -C release lint-docker`.
- Ran `make -C ruby lint-docker`.