### PR TITLE
feat(compose): update dependency images

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,14 +180,14 @@ From `compose.yml`:
 | Service | Image | Ports (host:container) | Notes |
 |---|---|---:|---|
 | `postgres` | `postgres:18-trixie` | `5432:5432` | `POSTGRES_USER=test`, `POSTGRES_PASSWORD=test` |
-| `redis` | `redis:8` | `6379:6379` |  |
+| `redis` | `valkey/valkey:9` | `6379:6379` |  |
 | `aws` | `hectorvent/floci` | `4566:4566` | `SERVICES=s3,sqs,ssm` |
 | `vault` | `hashicorp/vault:1.21` | `8200:8200` | dev token: `vault-plaintext-root-token` |
 | `prometheus` | `prom/prometheus:v3` | `9090:9090` | depends on `mimir` |
 | `mimir` | `grafana/mimir` | `9009:9009` | mounts `./grafana` |
 | `loki` | `grafana/loki` | `3100:3100` | mounts `./grafana` |
 | `memcached` | `memcached:1.6` | `11211:11211` | cache backend for `tempo` |
-| `tempo` | `grafana/tempo:2.10.1` | `3200:3200` | depends on `memcached` |
+| `tempo` | `grafana/tempo:2.10` | `3200:3200` | depends on `memcached` |
 | `otel-collector` | `otel/opentelemetry-collector-contrib` | `4317:4317`, `4318:4318` | OTLP gRPC/HTTP ingress |
 | `grafana` | `grafana/grafana-oss` | `10000:3000` | depends on metrics/logs/traces stack |
 | `status` | `alexfalkowski/status` | `15000:8080`, `15001:6060` | mounts `./status` |

--- a/compose.yml
+++ b/compose.yml
@@ -9,7 +9,7 @@ services:
       - "5432:5432"
 
   redis:
-    image: docker.io/redis:8
+    image: docker.io/valkey/valkey:9
     restart: always
     ports:
       - "6379:6379"
@@ -70,7 +70,7 @@ services:
       - "11211:11211"
 
   tempo:
-    image: docker.io/grafana/tempo:2.10.1
+    image: docker.io/grafana/tempo:2.10
     restart: always
     ports:
       - 3200:3200


### PR DESCRIPTION
## What

- Replace the local `redis` service image with `valkey/valkey:9`.
- Update the Tempo image from `grafana/tempo:2.10.1` to `grafana/tempo:2.10`.
- Update the README service table to match `compose.yml`.

## Why

- Moves the Redis-compatible local dependency stack to Valkey.
- Keeps Tempo on the latest stable `2.10.x` patch release.
- Keeps documented service images aligned with the Compose configuration.

## Testing

- Ran `scripts/compose config`; Compose rendered successfully.
- Ran `make lint`; hadolint and shellcheck passed.