### PR TITLE
feat(compose): update tempo image tag to latest patch

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -70,7 +70,7 @@ services:
       - "11211:11211"
 
   tempo:
-    image: docker.io/grafana/tempo:2.10
+    image: docker.io/grafana/tempo:2.10.5
     restart: always
     ports:
       - 3200:3200


### PR DESCRIPTION
## What
- Updated the Tempo image in `compose.yml` from `docker.io/grafana/tempo:2.10` to `docker.io/grafana/tempo:2.10.5`.

## Why
- The `2.10` shorthand tag does not exist on Docker Hub, causing `make start` / compose startup to fail with `manifest unknown`.
- `2.10.5` is a concrete pullable patch tag for the current Tempo 2.10 line.

## Testing
- Ran `docker manifest inspect docker.io/grafana/tempo:2.10.5` successfully.
- Ran `docker compose -f compose.yml config --quiet` successfully.