### PR TITLE
build(ci): include shared scripts in image filters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,31 +13,37 @@ workflows:
             .circleci/.* docker true
             Makefile docker true
             make/docker.mk docker true
+            scripts/.* docker true
             docker/.* docker true
 
             .circleci/.* go true
             Makefile go true
             make/docker.mk go true
+            scripts/.* go true
             go/.* go true
 
             .circleci/.* k8s true
             Makefile k8s true
             make/docker.mk k8s true
+            scripts/.* k8s true
             k8s/.* k8s true
 
             .circleci/.* release true
             Makefile release true
             make/docker.mk release true
+            scripts/.* release true
             release/.* release true
 
             .circleci/.* root true
             Makefile root true
             make/docker.mk root true
+            scripts/.* root true
             root/.* root true
 
             .circleci/.* ruby true
             Makefile ruby true
             make/docker.mk ruby true
+            scripts/.* ruby true
             ruby/.* ruby true
           base-revision: origin/master
           resource_class: large


### PR DESCRIPTION
## What
- Added shared `scripts/.*` path-filter mappings for every image family.

## Why
- Ensures shared installer and helper script changes trigger the image pipelines that consume them.

## Testing
- `gmake lint`
