### PR TITLE
build(make): set docker platforms explicitly

### DIFF
--- a/make/docker.mk
+++ b/make/docker.mk
@@ -8,11 +8,11 @@ push-docker:
 
 # Build platform docker image.
 build-platform-docker:
-	docker build -f Dockerfile -t alexfalkowski/$(IMAGE):$(VERSION).$(platform) ..
+	docker build --platform linux/$(platform) -f Dockerfile -t alexfalkowski/$(IMAGE):$(VERSION).$(platform) ..
 
 # Push built platform docker image.
 push-platform-docker:
-	docker build -f Dockerfile -t alexfalkowski/$(IMAGE):$(VERSION).$(platform) --push ..
+	docker build --platform linux/$(platform) -f Dockerfile -t alexfalkowski/$(IMAGE):$(VERSION).$(platform) --push ..
 
 manifest-platform-version-docker:
 	docker manifest create alexfalkowski/$(IMAGE):$(VERSION) --amend alexfalkowski/$(IMAGE):$(VERSION).amd64 --amend alexfalkowski/$(IMAGE):$(VERSION).arm64


### PR DESCRIPTION
## What
- Added `--platform linux/$(platform)` to platform-specific Docker build and push targets.

## Why
- Makes `platform=amd64` and `platform=arm64` control the actual image architecture, not only the tag suffix.

## Testing
- `gmake lint`
