### PR TITLE
feat(root): verify go downloads before extraction

### DIFF
--- a/root/Dockerfile
+++ b/root/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   docker-compose \
   docker.io \
   git \
+  jq \
   libc6-dev \
   libffi-dev \
   libgdbm-dev \

--- a/root/Makefile
+++ b/root/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=root
-VERSION:=3.5
+VERSION:=3.6
 
 include ../make/docker.mk

--- a/root/scripts/install-image-tool.d/go
+++ b/root/scripts/install-image-tool.d/go
@@ -6,5 +6,12 @@ asset="go${version}.linux-${arch}.tar.gz"
 base_url="https://go.dev/dl"
 
 download "$base_url/$asset" "$asset"
+download "$base_url/?mode=json&include=all" downloads.json
+
+jq -r --arg asset "$asset" '
+  .[].files[] | select(.filename == $asset) | .sha256
+' downloads.json > "$asset.sha256"
+
+verify_digest_file "$asset.sha256" "$asset"
 
 tar -C /usr/local -xf "$asset"


### PR DESCRIPTION
## What
- Added `jq` to the base image package set.
- Verified Go tarballs against Go download metadata before extraction.
- Bumped the image version to 3.6.

## Why
- Prevents corrupted or tampered Go toolchain archives from being installed into the base image.

## Testing
- `gmake lint`
- `gmake -C root build-docker`
