### PR TITLE
feat(security): remove passwordless sudo from root image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,9 @@ Docker images plus a `compose.yml` local dependency stack.
 
 - Image `Makefile`s set `IMAGE` and `VERSION`, then include `../make/docker.mk`.
 - `make/docker.mk` builds from the repo root context with `docker build -f Dockerfile ... ..`.
+- Updating `root/` is a two-stage process driven by the maintainer:
+  1. First update only `root/` and bump `root/Makefile`'s `VERSION`; use a minor bump unless the change alters the root image contract in a major-version-worthy way, including major upgrades to dependencies shipped by the root image.
+  2. After the new root image is published, update the Dockerfiles that depend on `alexfalkowski/root` and bump each dependent image `VERSION` in a separate change. If root had a major bump, dependents get a major bump; otherwise dependents get a minor bump.
 - Keep `.dockerignore` current when adding large or sensitive top-level paths.
 - Dockerfiles call `install-image-tool <tool> <version>` and `install-go-tool <module> <version>`; run `clean-go` after Go tool installs.
 - Hadolint suppressions live in each image directory's `.hadolint.yaml`; there is no top-level hadolint config.

--- a/root/Dockerfile
+++ b/root/Dockerfile
@@ -27,15 +27,12 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   netcat-openbsd \
   openssh-client \
   pkg-config \
-  sudo \
   xz-utils \
   zlib1g-dev \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN groupadd --gid 3434 circleci \
-  && useradd --uid 3434 --gid circleci --create-home --shell /bin/bash circleci \
-  && echo "circleci ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/circleci \
-  && chmod 0440 /etc/sudoers.d/circleci
+  && useradd --uid 3434 --gid circleci --create-home --shell /bin/bash circleci
 
 ENV GO_VERSION=1.26.3
 

--- a/root/Makefile
+++ b/root/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=root
-VERSION:=3.6
+VERSION:=3.7
 
 include ../make/docker.mk


### PR DESCRIPTION
## What

- Remove `sudo` from the root image package list.
- Stop writing the passwordless `circleci` sudoers entry.
- Bump the root image version from `3.6` to `3.7`.
- Document the two-stage root image update process for future changes.

## Why

- Keep the root image on least-privilege defaults now that repo-owned images and CI do not depend on passwordless sudo.
- Make it explicit that dependent images move to a new root image only after root has been published, with their own version bumps in a separate maintainer-driven change.

## Testing

- `gmake lint` - passed
- `rg -n "\bsudo\b|NOPASSWD|sudoers|FROM alexfalkowski/root|VERSION:=" -g "!bin/**" .` - passed
- `gmake -C root build-docker` - passed
- `docker run --rm alexfalkowski/root:3.7 bash -lc 'test ! -e /etc/sudoers.d/circleci && ! command -v sudo >/dev/null && id'` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
