### PR TITLE
feat(deps): use root 3.7 for dependent images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.6
+FROM alexfalkowski/root:3.7
 
 USER root
 WORKDIR /usr/local/bin

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=docker
-VERSION:=3.6
+VERSION:=3.7
 
 include ../make/docker.mk

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.6
+FROM alexfalkowski/root:3.7
 
 USER root
 WORKDIR /usr/local/bin

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=go
-VERSION:=4.8
+VERSION:=4.9
 
 include ../make/docker.mk

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.6
+FROM alexfalkowski/root:3.7
 
 USER root
 WORKDIR /usr/local/bin

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=k8s
-VERSION:=4.12
+VERSION:=4.13
 
 include ../make/docker.mk

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.6
+FROM alexfalkowski/root:3.7
 
 USER root
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=release
-VERSION:=8.6
+VERSION:=8.7
 
 include ../make/docker.mk

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.6
+FROM alexfalkowski/root:3.7
 
 USER root
 WORKDIR /usr/local/bin

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=ruby
-VERSION:=3.6
+VERSION:=3.7
 
 include ../make/docker.mk


### PR DESCRIPTION
## What

- Update dependent image Dockerfiles to use `alexfalkowski/root:3.7`.
- Minor-bump each dependent image version after the published root minor bump.

## Why

- Complete the second stage of the root image update process now that `root:3.7` is published.
- Keep dependent image versions aligned with the new root base image.

## Testing

- `gmake lint` - passed
- `rg -n "FROM alexfalkowski/root|VERSION:=" docker go k8s release ruby root` - passed
- `docker manifest inspect alexfalkowski/root:3.7` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
