### PR TITLE
feat(root): restore sudo in root image

### DIFF
--- a/root/Dockerfile
+++ b/root/Dockerfile
@@ -27,12 +27,15 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   netcat-openbsd \
   openssh-client \
   pkg-config \
+  sudo \
   xz-utils \
   zlib1g-dev \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN groupadd --gid 3434 circleci \
-  && useradd --uid 3434 --gid circleci --create-home --shell /bin/bash circleci
+  && useradd --uid 3434 --gid circleci --create-home --shell /bin/bash circleci \
+  && echo "circleci ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/circleci \
+  && chmod 0440 /etc/sudoers.d/circleci
 
 ENV GO_VERSION=1.26.3
 

--- a/root/Makefile
+++ b/root/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=root
-VERSION:=3.7
+VERSION:=3.8
 
 include ../make/docker.mk


### PR DESCRIPTION
## What

- Restore `sudo` in the root image package list.
- Restore the passwordless `circleci` sudoers entry required by tools such as `mkcert -install`.
- Bump the root image version from `3.7` to `3.8`.

## Why

- Keep workflows that install local trust roots working under the `circleci` user.
- Publish this as the first-stage root image correction before dependent images move to `root:3.8`.

## Testing

- `gmake lint` - passed
- `rg -n "\bsudo\b|NOPASSWD|sudoers|FROM alexfalkowski/root|VERSION:=" -g "!bin/**" .` - passed
- `gmake -C root build-docker` - passed
- `docker run --rm alexfalkowski/root:3.8 bash -lc 'test -e /etc/sudoers.d/circleci && command -v sudo >/dev/null && sudo -n id -u && id'` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
