### PR TITLE
feat(security): verify github release asset digests

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=docker
-VERSION:=3.8
+VERSION:=3.9
 
 include ../make/docker.mk

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=go
-VERSION:=4.11
+VERSION:=4.12
 
 include ../make/docker.mk

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=ruby
-VERSION:=3.8
+VERSION:=3.9
 
 include ../make/docker.mk

--- a/scripts/install-go-tool
+++ b/scripts/install-go-tool
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Install a pinned Go module binary with go install.
+
 set -euo pipefail
 
 if [[ "$#" -ne 2 ]]; then

--- a/scripts/install-image-tool
+++ b/scripts/install-image-tool
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Install a pinned binary tool with an image-specific installer snippet.
+
 set -euo pipefail
 
 if [[ "$#" -lt 1 || "$#" -gt 2 ]]; then
@@ -34,15 +36,18 @@ trap cleanup EXIT
 
 cd "$tmp_dir"
 
+# Print the Debian package architecture for asset selection.
 debian_arch() {
   dpkg --print-architecture
 }
 
+# Fail when an installer snippet does not support the current architecture.
 unsupported_arch() {
   echo "unsupported arch: $1" >&2
   exit 1
 }
 
+# Download a release asset to the temporary working directory.
 download() {
   local url="$1"
   local output="$2"
@@ -50,6 +55,7 @@ download() {
   curl -fsSLo "$output" "$url"
 }
 
+# Verify an asset against a digest file containing only the checksum.
 verify_digest_file() {
   local digest_file="$1"
   local asset="$2"
@@ -57,13 +63,39 @@ verify_digest_file() {
   echo "$(cat "$digest_file")  $asset" | sha256sum -c -
 }
 
+# Verify an asset against a checksum file containing asset names.
 verify_checksum_file() {
   local checksum_file="$1"
   local asset="$2"
 
-  grep "  ${asset}$" "$checksum_file" | sha256sum -c -
+  awk -v asset="$asset" '$2 == asset { print }' "$checksum_file" | sha256sum -c -
 }
 
+# Verify an asset against the SHA256 digest exposed by the GitHub release API.
+verify_github_asset_digest() {
+  local repo="$1"
+  local tag="$2"
+  local asset="$3"
+  local digest
+
+  digest="$(
+    curl -fsSL "https://api.github.com/repos/$repo/releases/tags/$tag" |
+      jq -r --arg asset "$asset" '.assets[] | select(.name == $asset) | .digest // empty'
+  )"
+
+  case "$digest" in
+    sha256:*)
+      ;;
+    *)
+      echo "missing sha256 digest for $repo $tag $asset" >&2
+      exit 1
+      ;;
+  esac
+
+  echo "${digest#sha256:}  $asset" | sha256sum -c -
+}
+
+# Install a verified binary into the image PATH.
 install_binary() {
   local source="$1"
   local target="$2"

--- a/scripts/install-image-tool.d/codecov
+++ b/scripts/install-image-tool.d/codecov
@@ -10,5 +10,6 @@ esac
 
 base_url="https://github.com/getsentry/prevent-cli/releases/download/${version}"
 
-download "$base_url/$asset" codecovcli
-install_binary codecovcli codecovcli
+download "$base_url/$asset" "$asset"
+verify_github_asset_digest getsentry/prevent-cli "$version" "$asset"
+install_binary "$asset" codecovcli

--- a/scripts/install-image-tool.d/shellcheck
+++ b/scripts/install-image-tool.d/shellcheck
@@ -12,6 +12,7 @@ asset="shellcheck-${version}.linux.${arch}.tar.xz"
 base_url="https://github.com/koalaman/shellcheck/releases/download/${version}"
 
 download "$base_url/$asset" "$asset"
+verify_github_asset_digest koalaman/shellcheck "$version" "$asset"
 
 tar -xJf "$asset"
 install_binary "shellcheck-${version}/shellcheck" shellcheck


### PR DESCRIPTION
## What

- Add a shared installer helper that verifies GitHub release asset SHA256 digests.
- Verify ShellCheck and Codecov CLI downloads before installing them.
- Bump the Docker, Go, and Ruby image versions for rebuilt images that include the hardened installers.

## Why

- ShellCheck and Codecov publish GitHub release asset digests for the pinned assets, so the image builds can fail closed when a downloaded asset does not match the release metadata.
- The Docker, Go, and Ruby images directly install those tools and need new image versions for publication.

## Testing

- `gmake lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
