### PR TITLE
feat(deps): require explicit tool versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Each top-level directory is an image (or runtime config used by the compose stac
   - `scripts/clean` (prunes unused images)
   - `scripts/clean-go` (shared Go cache cleanup runner: `clean-go`)
   - `scripts/install-go-tool` (shared Go build-time installer runner: `install-go-tool <module> <version>`)
-  - `scripts/install-image-tool` (shared image build-time installer runner: `install-image-tool <tool> [version]`)
+  - `scripts/install-image-tool` (shared image build-time installer runner: `install-image-tool <tool> <version>`)
   - `scripts/install-image-tool.d/` (shared install snippets used by multiple images)
   - `scripts/lint` (runs hadolint + shellcheck)
 
@@ -89,8 +89,8 @@ What it does (see `scripts/lint`):
 
 Each image directory has a `Makefile` that sets `IMAGE` and `VERSION` and then includes `../make/docker.mk`.
 The shared build targets run from the image directory but use the repository root as Docker build context so Dockerfiles can copy the shared installer script.
-Dockerfiles pass tool versions directly to `install-image-tool <tool> [version]`; installer snippets keep defaults for manual use.
-Go tools are installed with `install-go-tool <module> <version>`, which runs `go install <module>@<version>`.
+Dockerfiles pass tool versions directly to `install-image-tool <tool> <version>`; installer snippets do not provide fallback versions.
+Go tools are installed with `install-go-tool <module> <version>`, which runs `go install <module>@v<version>`.
 Go caches are cleaned with `clean-go`.
 
 Build an image locally:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,5 +7,5 @@ COPY scripts/install-image-tool /usr/local/bin/install-image-tool
 COPY scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
 COPY docker/scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
 RUN chmod +x /usr/local/bin/install-image-tool \
-  && install-image-tool hadolint v2.14.0 \
-  && install-image-tool shellcheck v0.11.0
+  && install-image-tool hadolint 2.14.0 \
+  && install-image-tool shellcheck 0.11.0

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=docker
-VERSION:=3.10
+VERSION:=3.11
 
 include ../make/docker.mk

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -13,13 +13,13 @@ COPY go/scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
 RUN chmod +x /usr/local/bin/install-image-tool \
   && chmod +x /usr/local/bin/install-go-tool \
   && chmod +x /usr/local/bin/clean-go \
-  && install-image-tool dockerize v0.9.3 \
-  && install-image-tool shellcheck v0.11.0 \
-  && install-image-tool hadolint v2.14.0 \
-  && install-image-tool buf v1.69.0 \
+  && install-image-tool dockerize 0.9.3 \
+  && install-image-tool shellcheck 0.11.0 \
+  && install-image-tool hadolint 2.14.0 \
+  && install-image-tool buf 1.69.0 \
   && install-image-tool trivy 0.70.0 \
-  && install-image-tool mkcert v1.4.4 \
-  && install-image-tool codecov v11.2.8 \
+  && install-image-tool mkcert 1.4.4 \
+  && install-image-tool codecov 11.2.8 \
   && install-image-tool golangci-lint "$GO_LINT_VERSION"
 
 USER circleci
@@ -30,10 +30,10 @@ RUN echo "$GO_LINT_VERSION" > .go-lint-version
 
 # Install go tools.
 ENV GOEXPERIMENT=jsonv2
-RUN install-go-tool github.com/alexfalkowski/gocovmerge/v2 v2.29.2 \
-  && install-go-tool golang.org/x/vuln/cmd/govulncheck v1.3.0 \
-  && install-go-tool gotest.tools/gotestsum v1.13.0 \
-  && install-go-tool golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment v0.44.0 \
-  && install-go-tool github.com/boyter/scc/v3 v3.7.0 \
-  && install-go-tool github.com/Zxilly/go-size-analyzer/cmd/gsa v1.13.0 \
+RUN install-go-tool github.com/alexfalkowski/gocovmerge/v2 2.29.2 \
+  && install-go-tool golang.org/x/vuln/cmd/govulncheck 1.3.0 \
+  && install-go-tool gotest.tools/gotestsum 1.13.0 \
+  && install-go-tool golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment 0.44.0 \
+  && install-go-tool github.com/boyter/scc/v3 3.7.0 \
+  && install-go-tool github.com/Zxilly/go-size-analyzer/cmd/gsa 1.13.0 \
   && clean-go

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=go
-VERSION:=4.13
+VERSION:=4.14
 
 include ../make/docker.mk

--- a/go/scripts/install-image-tool.d/golangci-lint
+++ b/go/scripts/install-image-tool.d/golangci-lint
@@ -1,9 +1,10 @@
 # shellcheck shell=bash
 
-version="${1:-2.11.4}"
+version="$1"
+tag="$(version_tag "$version")"
 arch="$(debian_arch)"
 asset="golangci-lint-${version}-linux-${arch}.tar.gz"
-base_url="https://github.com/golangci/golangci-lint/releases/download/v${version}"
+base_url="https://github.com/golangci/golangci-lint/releases/download/${tag}"
 checksum_file="golangci-lint-${version}-checksums.txt"
 
 download "$base_url/$asset" "$asset"

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -19,5 +19,5 @@ USER circleci
 WORKDIR /home/circleci/
 
 # Install go tools.
-RUN install-go-tool github.com/zegl/kube-score/cmd/kube-score v1.20.0 \
+RUN install-go-tool github.com/zegl/kube-score/cmd/kube-score 1.20.0 \
   && clean-go

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=k8s
-VERSION:=4.17
+VERSION:=4.18
 
 include ../make/docker.mk

--- a/k8s/scripts/install-image-tool.d/doctl
+++ b/k8s/scripts/install-image-tool.d/doctl
@@ -1,9 +1,10 @@
 # shellcheck shell=bash
 
-version="${1:-1.155.0}"
+version="$1"
+tag="$(version_tag "$version")"
 arch="$(debian_arch)"
 asset="doctl-${version}-linux-${arch}.tar.gz"
-base_url="https://github.com/digitalocean/doctl/releases/download/v${version}"
+base_url="https://github.com/digitalocean/doctl/releases/download/${tag}"
 checksum_file="doctl-${version}-checksums.sha256"
 
 download "$base_url/$asset" "$asset"

--- a/k8s/scripts/install-image-tool.d/kubescape
+++ b/k8s/scripts/install-image-tool.d/kubescape
@@ -1,9 +1,10 @@
 # shellcheck shell=bash
 
-version="${1:-4.0.5}"
+version="$1"
+tag="$(version_tag "$version")"
 arch="$(debian_arch)"
 asset="kubescape_${version}_linux_${arch}.tar.gz"
-base_url="https://github.com/kubescape/kubescape/releases/download/v${version}"
+base_url="https://github.com/kubescape/kubescape/releases/download/${tag}"
 
 download "$base_url/$asset" "$asset"
 download "$base_url/checksums.sha256" checksums.sha256

--- a/k8s/scripts/install-image-tool.d/pulumi
+++ b/k8s/scripts/install-image-tool.d/pulumi
@@ -1,6 +1,7 @@
 # shellcheck shell=bash
 
-version="${1:-3.232.0}"
+version="$1"
+tag="$(version_tag "$version")"
 
 case "$(debian_arch)" in
   amd64) arch="x64" ;;
@@ -8,8 +9,8 @@ case "$(debian_arch)" in
   *) unsupported_arch "$(debian_arch)" ;;
 esac
 
-asset="pulumi-v${version}-linux-${arch}.tar.gz"
-base_url="https://github.com/pulumi/pulumi/releases/download/v${version}"
+asset="pulumi-${tag}-linux-${arch}.tar.gz"
+base_url="https://github.com/pulumi/pulumi/releases/download/${tag}"
 checksum_file="pulumi-${version}-checksums.txt"
 
 download "$base_url/$asset" "$asset"

--- a/k8s/scripts/install-image-tool.d/vegeta
+++ b/k8s/scripts/install-image-tool.d/vegeta
@@ -1,9 +1,10 @@
 # shellcheck shell=bash
 
-version="${1:-12.12.0}"
+version="$1"
+tag="$(version_tag "$version")"
 arch="$(debian_arch)"
 asset="vegeta_${version}_linux_${arch}.tar.gz"
-base_url="https://github.com/tsenart/vegeta/releases/download/v${version}"
+base_url="https://github.com/tsenart/vegeta/releases/download/${tag}"
 checksum_file="vegeta_${version}_checksums.txt"
 
 download "$base_url/$asset" "$asset"

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -35,5 +35,5 @@ RUN git config --global user.email "ci@lean-thoughts.com" \
   && git config --global user.name "lean-thoughts-ci"
 
 # Install go tools.
-RUN install-go-tool github.com/alexfalkowski/infraops/v2/cmd/bump v2.480.0 \
+RUN install-go-tool github.com/alexfalkowski/infraops/v2/cmd/bump 2.480.0 \
   && clean-go

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=release
-VERSION:=8.10
+VERSION:=8.11
 
 include ../make/docker.mk

--- a/release/scripts/install-image-tool.d/gh
+++ b/release/scripts/install-image-tool.d/gh
@@ -1,9 +1,10 @@
 # shellcheck shell=bash
 
-version="${1:-2.92.0}"
+version="$1"
+tag="$(version_tag "$version")"
 arch="$(debian_arch)"
 asset="gh_${version}_linux_${arch}.deb"
-base_url="https://github.com/cli/cli/releases/download/v${version}"
+base_url="https://github.com/cli/cli/releases/download/${tag}"
 checksum_file="gh_${version}_checksums.txt"
 
 download "$base_url/$asset" "$asset"

--- a/release/scripts/install-image-tool.d/goreleaser
+++ b/release/scripts/install-image-tool.d/goreleaser
@@ -1,9 +1,10 @@
 # shellcheck shell=bash
 
-version="${1:-2.15.4}"
+version="$1"
+tag="$(version_tag "$version")"
 arch="$(debian_arch)"
 asset="goreleaser_${version}_${arch}.deb"
-base_url="https://github.com/goreleaser/goreleaser/releases/download/v${version}"
+base_url="https://github.com/goreleaser/goreleaser/releases/download/${tag}"
 
 download "$base_url/$asset" "$asset"
 download "$base_url/checksums.txt" checksums.txt

--- a/release/scripts/install-image-tool.d/uplift
+++ b/release/scripts/install-image-tool.d/uplift
@@ -1,9 +1,10 @@
 # shellcheck shell=bash
 
-version="${1:-2.26.0}"
+version="$1"
+tag="$(version_tag "$version")"
 arch="$(debian_arch)"
 asset="uplift_${version}_${arch}.deb"
-base_url="https://github.com/gembaadvantage/uplift/releases/download/v${version}"
+base_url="https://github.com/gembaadvantage/uplift/releases/download/${tag}"
 
 download "$base_url/$asset" "$asset"
 download "$base_url/checksums.txt" checksums.txt

--- a/root/scripts/install-image-tool.d/go
+++ b/root/scripts/install-image-tool.d/go
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-version="${1:-1.26.2}"
+version="$1"
 arch="$(debian_arch)"
 asset="go${version}.linux-${arch}.tar.gz"
 base_url="https://go.dev/dl"

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -11,17 +11,17 @@ COPY ruby/scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
 RUN chmod +x /usr/local/bin/install-image-tool \
   && chmod +x /usr/local/bin/install-go-tool \
   && chmod +x /usr/local/bin/clean-go \
-  && install-image-tool dockerize v0.9.3 \
-  && install-image-tool shellcheck v0.11.0 \
-  && install-image-tool hadolint v2.14.0 \
-  && install-image-tool buf v1.69.0 \
+  && install-image-tool dockerize 0.9.3 \
+  && install-image-tool shellcheck 0.11.0 \
+  && install-image-tool hadolint 2.14.0 \
+  && install-image-tool buf 1.69.0 \
   && install-image-tool trivy 0.70.0 \
-  && install-image-tool mkcert v1.4.4 \
-  && install-image-tool codecov v11.2.8
+  && install-image-tool mkcert 1.4.4 \
+  && install-image-tool codecov 11.2.8
 
 USER circleci
 WORKDIR /home/circleci/
 
 # Install go tools.
-RUN install-go-tool github.com/boyter/scc/v3 v3.7.0 \
+RUN install-go-tool github.com/boyter/scc/v3 3.7.0 \
   && clean-go

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=ruby
-VERSION:=3.10
+VERSION:=3.11
 
 include ../make/docker.mk

--- a/scripts/install-go-tool
+++ b/scripts/install-go-tool
@@ -26,4 +26,4 @@ case "$version" in
     ;;
 esac
 
-go install "$module@$version"
+go install "$module@v$version"

--- a/scripts/install-image-tool
+++ b/scripts/install-image-tool
@@ -4,16 +4,24 @@
 
 set -euo pipefail
 
-if [[ "$#" -lt 1 || "$#" -gt 2 ]]; then
-  echo "usage: install-image-tool <tool> [version]" >&2
+if [[ "$#" -ne 2 ]]; then
+  echo "usage: install-image-tool <tool> <version>" >&2
   exit 2
 fi
 
 readonly tool="$1"
+readonly tool_version="$2"
 
 case "$tool" in
   "" | *[!a-zA-Z0-9._-]*)
     echo "invalid tool: $tool" >&2
+    exit 2
+    ;;
+esac
+
+case "$tool_version" in
+  "" | *[[:space:]]*)
+    echo "invalid version: $tool_version" >&2
     exit 2
     ;;
 esac
@@ -45,6 +53,13 @@ debian_arch() {
 unsupported_arch() {
   echo "unsupported arch: $1" >&2
   exit 1
+}
+
+# Return a release tag with a leading v prefix.
+version_tag() {
+  local version="$1"
+
+  echo "v${version}"
 }
 
 # Download a release asset to the temporary working directory.
@@ -104,4 +119,4 @@ install_binary() {
 }
 
 # shellcheck source=/dev/null
-. "$installer" "${2:-}"
+. "$installer" "$tool_version"

--- a/scripts/install-image-tool.d/buf
+++ b/scripts/install-image-tool.d/buf
@@ -1,6 +1,7 @@
 # shellcheck shell=bash
 
-version="${1:-v1.69.0}"
+version="$1"
+tag="$(version_tag "$version")"
 
 case "$(uname -m)" in
   x86_64 | amd64) arch="x86_64" ;;
@@ -9,7 +10,7 @@ case "$(uname -m)" in
 esac
 
 asset="buf-Linux-${arch}"
-base_url="https://github.com/bufbuild/buf/releases/download/${version}"
+base_url="https://github.com/bufbuild/buf/releases/download/${tag}"
 
 download "$base_url/$asset" "$asset"
 download "$base_url/sha256.txt" sha256.txt

--- a/scripts/install-image-tool.d/codecov
+++ b/scripts/install-image-tool.d/codecov
@@ -1,6 +1,7 @@
 # shellcheck shell=bash
 
-version="${1:-v11.2.8}"
+version="$1"
+tag="$(version_tag "$version")"
 
 case "$(uname -m)" in
   x86_64 | amd64) asset="codecovcli_linux" ;;
@@ -8,8 +9,8 @@ case "$(uname -m)" in
   *) unsupported_arch "$(uname -m)" ;;
 esac
 
-base_url="https://github.com/getsentry/prevent-cli/releases/download/${version}"
+base_url="https://github.com/getsentry/prevent-cli/releases/download/${tag}"
 
 download "$base_url/$asset" "$asset"
-verify_github_asset_digest getsentry/prevent-cli "$version" "$asset"
+verify_github_asset_digest getsentry/prevent-cli "$tag" "$asset"
 install_binary "$asset" codecovcli

--- a/scripts/install-image-tool.d/dockerize
+++ b/scripts/install-image-tool.d/dockerize
@@ -1,9 +1,10 @@
 # shellcheck shell=bash
 
-version="${1:-v0.9.3}"
+version="$1"
+tag="$(version_tag "$version")"
 arch="$(debian_arch)"
-asset="dockerize-linux-${arch}-${version}.tar.gz"
-base_url="https://github.com/jwilder/dockerize/releases/download/${version}"
+asset="dockerize-linux-${arch}-${tag}.tar.gz"
+base_url="https://github.com/jwilder/dockerize/releases/download/${tag}"
 
 download "$base_url/$asset" "$asset"
 

--- a/scripts/install-image-tool.d/hadolint
+++ b/scripts/install-image-tool.d/hadolint
@@ -1,6 +1,7 @@
 # shellcheck shell=bash
 
-version="${1:-v2.14.0}"
+version="$1"
+tag="$(version_tag "$version")"
 
 case "$(uname -m)" in
   x86_64 | amd64) arch="x86_64" ;;
@@ -9,7 +10,7 @@ case "$(uname -m)" in
 esac
 
 asset="hadolint-linux-${arch}"
-base_url="https://github.com/hadolint/hadolint/releases/download/${version}"
+base_url="https://github.com/hadolint/hadolint/releases/download/${tag}"
 
 download "$base_url/$asset" "$asset"
 download "$base_url/$asset.sha256" "$asset.sha256"

--- a/scripts/install-image-tool.d/mkcert
+++ b/scripts/install-image-tool.d/mkcert
@@ -1,9 +1,10 @@
 # shellcheck shell=bash
 
-version="${1:-v1.4.4}"
+version="$1"
+tag="$(version_tag "$version")"
 arch="$(debian_arch)"
-asset="mkcert-${version}-linux-${arch}"
-base_url="https://github.com/FiloSottile/mkcert/releases/download/${version}"
+asset="mkcert-${tag}-linux-${arch}"
+base_url="https://github.com/FiloSottile/mkcert/releases/download/${tag}"
 
 download "$base_url/$asset" "$asset"
 install_binary "$asset" mkcert

--- a/scripts/install-image-tool.d/shellcheck
+++ b/scripts/install-image-tool.d/shellcheck
@@ -1,6 +1,7 @@
 # shellcheck shell=bash
 
-version="${1:-v0.11.0}"
+version="$1"
+tag="$(version_tag "$version")"
 
 case "$(uname -m)" in
   x86_64 | amd64) arch="x86_64" ;;
@@ -8,11 +9,11 @@ case "$(uname -m)" in
   *) unsupported_arch "$(uname -m)" ;;
 esac
 
-asset="shellcheck-${version}.linux.${arch}.tar.xz"
-base_url="https://github.com/koalaman/shellcheck/releases/download/${version}"
+asset="shellcheck-${tag}.linux.${arch}.tar.xz"
+base_url="https://github.com/koalaman/shellcheck/releases/download/${tag}"
 
 download "$base_url/$asset" "$asset"
-verify_github_asset_digest koalaman/shellcheck "$version" "$asset"
+verify_github_asset_digest koalaman/shellcheck "$tag" "$asset"
 
 tar -xJf "$asset"
-install_binary "shellcheck-${version}/shellcheck" shellcheck
+install_binary "shellcheck-${tag}/shellcheck" shellcheck

--- a/scripts/install-image-tool.d/trivy
+++ b/scripts/install-image-tool.d/trivy
@@ -1,6 +1,7 @@
 # shellcheck shell=bash
 
-version="${1:-0.70.0}"
+version="$1"
+tag="$(version_tag "$version")"
 
 case "$(debian_arch)" in
   amd64) arch="64bit" ;;
@@ -9,7 +10,7 @@ case "$(debian_arch)" in
 esac
 
 asset="trivy_${version}_Linux-${arch}.tar.gz"
-base_url="https://github.com/aquasecurity/trivy/releases/download/v${version}"
+base_url="https://github.com/aquasecurity/trivy/releases/download/${tag}"
 checksum_file="trivy_${version}_checksums.txt"
 
 download "$base_url/$asset" "$asset"


### PR DESCRIPTION
## What

- Require `install-image-tool` callers to pass an explicit version and remove fallback versions from installer snippets.
- Normalize Dockerfile tool versions to omit a leading `v`, while image snippets derive `v`-prefixed release tags only where needed.
- Update `install-go-tool` to append the Go module `v` prefix itself and bump minor image versions for Dockerfiles that changed.
- Update README guidance for the explicit-version contract.

## Why

- Keeps tool version arguments consistent across Dockerfiles and avoids silent snippet defaults when a version is omitted.

## Testing

- `gmake lint` - passed
- `scripts/install-image-tool gh` - passed, failed with usage because the required version was omitted
- `git diff --check` - passed
