### PR TITLE
feat(scripts): fail duplicate tool updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Each top-level directory is an image (or runtime config used by the compose stac
   - `scripts/compose` (prefers `podman compose`, falls back to `docker compose`)
   - `scripts/clean` (prunes unused images)
   - `scripts/clean-go` (shared Go cache cleanup runner: `clean-go`)
-  - `scripts/install-go-tool` (shared Go build-time installer runner: `install-go-tool <module> <version>`)
-  - `scripts/install-image-tool` (shared image build-time installer runner: `install-image-tool <tool> <version>`)
+  - `scripts/install-go-tool` (shared Go build-time installer runner: `install-go-tool <module> [current-version] <version>`)
+  - `scripts/install-image-tool` (shared image build-time installer runner: `install-image-tool <tool> [current-version] <version>`)
   - `scripts/install-image-tool.d/` (shared install snippets used by multiple images)
   - `scripts/lint` (runs hadolint + shellcheck)
 
@@ -90,7 +90,9 @@ What it does (see `scripts/lint`):
 Each image directory has a `Makefile` that sets `IMAGE` and `VERSION` and then includes `../make/docker.mk`.
 The shared build targets run from the image directory but use the repository root as Docker build context so Dockerfiles can copy the shared installer script.
 Dockerfiles pass tool versions directly to `install-image-tool <tool> <version>`; installer snippets do not provide fallback versions.
+Update helpers can also pass the current version first, as `install-image-tool <tool> <current-version> <version>`, to fail when the requested version is already current.
 Go tools are installed with `install-go-tool <module> <version>`, which runs `go install <module>@v<version>`.
+Update helpers can also pass the current version first, as `install-go-tool <module> <current-version> <version>`, to fail when the requested version is already current.
 Go caches are cleaned with `clean-go`.
 
 Build an image locally:

--- a/scripts/install-go-tool
+++ b/scripts/install-go-tool
@@ -4,13 +4,19 @@
 
 set -euo pipefail
 
-if [[ "$#" -ne 2 ]]; then
-  echo "usage: install-go-tool <module> <version>" >&2
+if [[ "$#" -ne 2 && "$#" -ne 3 ]]; then
+  echo "usage: install-go-tool <module> [current-version] <version>" >&2
   exit 2
 fi
 
 readonly module="$1"
-readonly version="$2"
+if [[ "$#" -eq 3 ]]; then
+  readonly current_version="$2"
+  readonly version="$3"
+else
+  readonly current_version=""
+  readonly version="$2"
+fi
 
 case "$module" in
   "" | *@* | *[[:space:]]*)
@@ -25,5 +31,10 @@ case "$version" in
     exit 2
     ;;
 esac
+
+if [[ "$current_version" == "$version" ]]; then
+  echo "$module $version is already up to date" >&2
+  exit 1
+fi
 
 go install "$module@v$version"

--- a/scripts/install-image-tool
+++ b/scripts/install-image-tool
@@ -4,13 +4,19 @@
 
 set -euo pipefail
 
-if [[ "$#" -ne 2 ]]; then
-  echo "usage: install-image-tool <tool> <version>" >&2
+if [[ "$#" -ne 2 && "$#" -ne 3 ]]; then
+  echo "usage: install-image-tool <tool> [current-version] <version>" >&2
   exit 2
 fi
 
 readonly tool="$1"
-readonly tool_version="$2"
+if [[ "$#" -eq 3 ]]; then
+  readonly current_tool_version="$2"
+  readonly tool_version="$3"
+else
+  readonly current_tool_version=""
+  readonly tool_version="$2"
+fi
 
 case "$tool" in
   "" | *[!a-zA-Z0-9._-]*)
@@ -25,6 +31,11 @@ case "$tool_version" in
     exit 2
     ;;
 esac
+
+if [[ "$current_tool_version" == "$tool_version" ]]; then
+  echo "$tool $tool_version is already up to date" >&2
+  exit 1
+fi
 
 readonly installer="/usr/local/lib/install-image-tool/$tool"
 


### PR DESCRIPTION
## What

- Added optional current-version arguments to the Go and image tool installer wrappers.
- Fail with an already-up-to-date message when the current version matches the requested version.
- Documented the optional update-helper form in the README.

## Why

- Updating a tool to the version it already uses should fail clearly instead of behaving like a no-op.

## Testing

- `scripts/install-go-tool github.com/example/tool 1.2.3 1.2.3` - passed, verified duplicate Go tool updates fail as expected.
- `scripts/install-image-tool foo 1.2.3 1.2.3` - passed, verified duplicate image tool updates fail as expected.
- `bash -n scripts/install-go-tool scripts/install-image-tool` - passed.
- `gmake lint` - passed.
