### PR TITLE
feat(k8s): install kubectl client

### DIFF
--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -12,6 +12,7 @@ RUN chmod +x /usr/local/bin/install-image-tool \
   && chmod +x /usr/local/bin/clean-go \
   && install-image-tool vegeta 12.12.0 \
   && install-image-tool doctl 1.160.1 \
+  && install-image-tool kubectl 1.36.1 \
   && install-image-tool kubescape 4.0.9 \
   && install-image-tool pulumi 3.245.0
 

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=k8s
-VERSION:=4.24
+VERSION:=4.25
 
 include ../make/docker.mk

--- a/k8s/scripts/install-image-tool.d/kubectl
+++ b/k8s/scripts/install-image-tool.d/kubectl
@@ -1,0 +1,17 @@
+# shellcheck shell=bash
+
+version="$1"
+tag="$(version_tag "$version")"
+
+case "$(debian_arch)" in
+  amd64 | arm64) arch="$(debian_arch)" ;;
+  *) unsupported_arch "$(debian_arch)" ;;
+esac
+
+base_url="https://dl.k8s.io/release/${tag}/bin/linux/${arch}"
+
+download "$base_url/kubectl" kubectl
+download "$base_url/kubectl.sha256" kubectl.sha256
+verify_digest_file kubectl.sha256 kubectl
+
+install_binary kubectl kubectl


### PR DESCRIPTION
## What

- Install kubectl 1.36.1 in the Kubernetes tooling image.
- Verify the downloaded binary with the upstream SHA256 file and support linux/amd64 and linux/arm64 builds.
- Bump the image version to 4.25.

## Why

- Workflows that use this image can run kubectl without failing with `/bin/sh: 1: kubectl: not found`.
- The installer keeps the binary pinned and verified like the other image tools.

## Testing

- `gmake lint` - passed
- `gmake -C k8s build-docker` - passed
- `docker run --rm alexfalkowski/k8s:4.25 kubectl version --client` - passed
