### PR TITLE
feat(release): use tag handoff for packaging

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=release
-VERSION:=8.14
+VERSION:=8.15
 
 include ../make/docker.mk

--- a/release/package
+++ b/release/package
@@ -4,12 +4,8 @@
 set -eo pipefail
 
 readonly releaser=$(find . -name "*goreleaser*" -not -path "*vendor*")
+readonly version_file="${APP_VERSION_FILE:-/tmp/workspace/release-version.txt}"
 
-if [ -n "$releaser" ]; then
-  readonly message=$(git log --pretty=format:"%s" -n 1)
-  readonly message_pattern='^(feat|fix)(\([^)]*\))?!?:'
-
-  if [[ "$message" =~ $message_pattern ]]; then
-    goreleaser release
-  fi
+if [[ -n "$releaser" && -s "$version_file" ]]; then
+  goreleaser release
 fi

--- a/release/version
+++ b/release/version
@@ -8,11 +8,12 @@ readonly version_file="${APP_VERSION_FILE:-/tmp/workspace/release-version.txt}"
 mkdir -p "$(dirname "$version_file")"
 rm -f "$version_file"
 
+readonly previous_version="$(git tag --points-at HEAD | sort -V | tail -1)"
+
 uplift release --skip-changelog --config-dir /etc/uplift
 
-readonly message=$(git log --pretty=format:"%s" -n 1)
-readonly message_pattern='^(feat|fix)(\([^)]*\))?!?:'
+readonly version="$(git tag --points-at HEAD | sort -V | tail -1)"
 
-if [[ "$message" =~ $message_pattern ]]; then
-  git tag | sort -V | tail -1 > "$version_file"
+if [[ -n "$version" && "$version" != "$previous_version" ]]; then
+  echo "$version" > "$version_file"
 fi


### PR DESCRIPTION
## What

- Use the tag created by uplift as the handoff between versioning and packaging.
- Write the new tag to the shared version file only when uplift creates a fresh tag on HEAD.
- Run GoReleaser when that handoff file is present and non-empty, and bump the release image to 8.15.

## Why

- The previous commit-message check missed uplift release commits shaped like `chore(release): v... [ci skip]`, so packaging could be skipped even after a tag was created.
- A tag-based versioning signal keeps package execution aligned with the artifact uplift actually created while preserving the existing version-file contract used by the scripts.

## Testing

- `gmake lint` - passed
- Disposable git repository simulation - passed; covered new tag creation, packaging from a non-empty handoff file, empty handoff files, no tag creation, and pre-existing HEAD tags.
- `git diff --check` - passed
