### PR TITLE
feat(trivy): scan images before publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,37 +12,37 @@ workflows:
           mapping: |
             .circleci/.* docker true
             Makefile docker true
-            make/docker.mk docker true
+            make/.* docker true
             scripts/.* docker true
             docker/.* docker true
 
             .circleci/.* go true
             Makefile go true
-            make/docker.mk go true
+            make/.* go true
             scripts/.* go true
             go/.* go true
 
             .circleci/.* k8s true
             Makefile k8s true
-            make/docker.mk k8s true
+            make/.* k8s true
             scripts/.* k8s true
             k8s/.* k8s true
 
             .circleci/.* release true
             Makefile release true
-            make/docker.mk release true
+            make/.* release true
             scripts/.* release true
             release/.* release true
 
             .circleci/.* root true
             Makefile root true
-            make/docker.mk root true
+            make/.* root true
             scripts/.* root true
             root/.* root true
 
             .circleci/.* ruby true
             Makefile ruby true
-            make/docker.mk ruby true
+            make/.* ruby true
             scripts/.* ruby true
             ruby/.* ruby true
           base-revision: origin/master

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -72,7 +72,7 @@ jobs:
       - run: git submodule update --init
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: make -C docker platform=amd64 build-platform-docker
+      - run: make -C docker platform=amd64 test-platform-docker
     resource_class: large
   docker-push-amd64:
     docker:
@@ -87,7 +87,7 @@ jobs:
       - run:
           name: make login
           command: echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-      - run: make -C docker platform=amd64 push-platform-docker
+      - run: make -C docker platform=amd64 release-platform-docker
     resource_class: large
   docker-build-arm64:
     docker:
@@ -100,7 +100,7 @@ jobs:
       - run: git submodule update --init
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: make -C docker platform=arm64 build-platform-docker
+      - run: make -C docker platform=arm64 test-platform-docker
     resource_class: arm.large
   docker-push-arm64:
     docker:
@@ -115,7 +115,7 @@ jobs:
       - run:
           name: make login
           command: echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-      - run: make -C docker platform=arm64 push-platform-docker
+      - run: make -C docker platform=arm64 release-platform-docker
     resource_class: arm.large
   docker-manifest:
     docker:
@@ -144,7 +144,7 @@ jobs:
       - run: git submodule update --init
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: make -C go platform=amd64 build-platform-docker
+      - run: make -C go platform=amd64 test-platform-docker
     resource_class: large
   go-push-amd64:
     docker:
@@ -159,7 +159,7 @@ jobs:
       - run:
           name: make login
           command: echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-      - run: make -C go platform=amd64 push-platform-docker
+      - run: make -C go platform=amd64 release-platform-docker
     resource_class: large
   go-build-arm64:
     docker:
@@ -172,7 +172,7 @@ jobs:
       - run: git submodule update --init
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: make -C go platform=arm64 build-platform-docker
+      - run: make -C go platform=arm64 test-platform-docker
     resource_class: arm.large
   go-push-arm64:
     docker:
@@ -187,7 +187,7 @@ jobs:
       - run:
           name: make login
           command: echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-      - run: make -C go platform=arm64 push-platform-docker
+      - run: make -C go platform=arm64 release-platform-docker
     resource_class: arm.large
   go-manifest:
     docker:
@@ -216,7 +216,7 @@ jobs:
       - run: git submodule update --init
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: make -C k8s platform=amd64 build-platform-docker
+      - run: make -C k8s platform=amd64 test-platform-docker
     resource_class: large
   k8s-push-amd64:
     docker:
@@ -231,7 +231,7 @@ jobs:
       - run:
           name: make login
           command: echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-      - run: make -C k8s platform=amd64 push-platform-docker
+      - run: make -C k8s platform=amd64 release-platform-docker
     resource_class: large
   k8s-build-arm64:
     docker:
@@ -244,7 +244,7 @@ jobs:
       - run: git submodule update --init
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: make -C k8s platform=arm64 build-platform-docker
+      - run: make -C k8s platform=arm64 test-platform-docker
     resource_class: arm.large
   k8s-push-arm64:
     docker:
@@ -259,7 +259,7 @@ jobs:
       - run:
           name: make login
           command: echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-      - run: make -C k8s platform=arm64 push-platform-docker
+      - run: make -C k8s platform=arm64 release-platform-docker
     resource_class: arm.large
   k8s-manifest:
     docker:
@@ -288,7 +288,7 @@ jobs:
       - run: git submodule update --init
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: make -C release platform=amd64 build-platform-docker
+      - run: make -C release platform=amd64 test-platform-docker
     resource_class: large
   release-push-amd64:
     docker:
@@ -303,7 +303,7 @@ jobs:
       - run:
           name: make login
           command: echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-      - run: make -C release platform=amd64 push-platform-docker
+      - run: make -C release platform=amd64 release-platform-docker
     resource_class: large
   release-build-arm64:
     docker:
@@ -316,7 +316,7 @@ jobs:
       - run: git submodule update --init
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: make -C release platform=arm64 build-platform-docker
+      - run: make -C release platform=arm64 test-platform-docker
     resource_class: arm.large
   release-push-arm64:
     docker:
@@ -331,7 +331,7 @@ jobs:
       - run:
           name: make login
           command: echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-      - run: make -C release platform=arm64 push-platform-docker
+      - run: make -C release platform=arm64 release-platform-docker
     resource_class: arm.large
   release-manifest:
     docker:
@@ -360,7 +360,7 @@ jobs:
       - run: git submodule update --init
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: make -C root platform=amd64 build-platform-docker
+      - run: make -C root platform=amd64 test-platform-docker
     resource_class: large
   root-push-amd64:
     docker:
@@ -375,7 +375,7 @@ jobs:
       - run:
           name: make login
           command: echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-      - run: make -C root platform=amd64 push-platform-docker
+      - run: make -C root platform=amd64 release-platform-docker
     resource_class: large
   root-build-arm64:
     docker:
@@ -388,7 +388,7 @@ jobs:
       - run: git submodule update --init
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: make -C root platform=arm64 build-platform-docker
+      - run: make -C root platform=arm64 test-platform-docker
     resource_class: arm.large
   root-push-arm64:
     docker:
@@ -403,7 +403,7 @@ jobs:
       - run:
           name: make login
           command: echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-      - run: make -C root platform=arm64 push-platform-docker
+      - run: make -C root platform=arm64 release-platform-docker
     resource_class: arm.large
   root-manifest:
     docker:
@@ -431,7 +431,7 @@ jobs:
       - run: git submodule update --init
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: make -C ruby platform=amd64 build-platform-docker
+      - run: make -C ruby platform=amd64 test-platform-docker
     resource_class: large
   ruby-push-amd64:
     docker:
@@ -446,7 +446,7 @@ jobs:
       - run:
           name: make login
           command: echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-      - run: make -C ruby platform=amd64 push-platform-docker
+      - run: make -C ruby platform=amd64 release-platform-docker
     resource_class: large
   ruby-build-arm64:
     docker:
@@ -459,7 +459,7 @@ jobs:
       - run: git submodule update --init
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: make -C ruby platform=arm64 build-platform-docker
+      - run: make -C ruby platform=arm64 test-platform-docker
     resource_class: arm.large
   ruby-push-arm64:
     docker:
@@ -474,7 +474,7 @@ jobs:
       - run:
           name: make login
           command: echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-      - run: make -C ruby platform=arm64 push-platform-docker
+      - run: make -C ruby platform=arm64 release-platform-docker
     resource_class: arm.large
   ruby-manifest:
     docker:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,8 @@ Docker images plus a `compose.yml` local dependency stack.
 ## Commands
 
 - `make lint`: lint Dockerfiles and shell scripts.
-- `make -C <dir> build-docker` / `lint-docker`: build or lint one image.
-- `make -C <dir> platform=amd64 build-platform-docker`: build a platform image.
+- `make -C <dir> build-docker` / `test-docker` / `release-docker`: build, build+scan, or build+scan+push one image.
+- `make -C <dir> platform=amd64 build-platform-docker` / `test-platform-docker` / `release-platform-docker`: build, build+scan, or build+scan+push a platform image.
 - `make -C <dir> manifest-platform-docker`: publish the multi-arch manifests.
 - `make docker-pull`, `make start`, `make stop`, `make logs service=<name>`: manage compose services.
 
@@ -47,7 +47,7 @@ Docker images plus a `compose.yml` local dependency stack.
 ## Gotchas
 
 - `.gitmodules` uses the SSH URL `git@github.com:alexfalkowski/bin.git`.
-- Push and manifest targets require DockerHub credentials.
+- Push, release, and manifest targets require DockerHub credentials.
 - `scripts/compose` prefers `podman compose` over `docker compose`.
 - `make clean` is destructive: it prunes all unused Docker or Podman images.
 - Mutable base image tags are intentional in this repository; do not flag tag-based `FROM` lines as review findings unless asked to make builds digest-pinned.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ stack):
 - `docker` (required for image build, push, and manifest targets)
 - `docker` or `podman` (required for compose and clean targets)
 - `hadolint` and `shellcheck` (required for `make lint`)
+- `trivy` (required for Docker image scan targets)
 
 > [!NOTE]
 > Examples below use `make`; substitute `gmake` if GNU Make is installed under
@@ -134,11 +135,18 @@ make -C go build-docker
 That produces a local image tagged like:
 
 - `alexfalkowski/go:<VERSION>` (based on `go/Makefile`)
+- `alexfalkowski/go` (equivalent to `:latest`)
 
 Build another image:
 
 ```sh
 make -C docker build-docker
+```
+
+Build and scan an image:
+
+```sh
+make -C go test-docker
 ```
 
 ### 🚀 Build/push platform-tagged images
@@ -157,11 +165,25 @@ make -C go platform=amd64 build-platform-docker
 make -C go platform=arm64 build-platform-docker
 ```
 
-Push (requires DockerHub login):
+Build and scan:
+
+```sh
+make -C go platform=amd64 test-platform-docker
+make -C go platform=arm64 test-platform-docker
+```
+
+Push an already-built platform image (requires DockerHub login):
 
 ```sh
 make -C go platform=amd64 push-platform-docker
 make -C go platform=arm64 push-platform-docker
+```
+
+Build, scan, and push a platform image (requires DockerHub login):
+
+```sh
+make -C go platform=amd64 release-platform-docker
+make -C go platform=arm64 release-platform-docker
 ```
 
 ### 🧩 Create multi-arch manifests

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -1,30 +1,53 @@
+DOCKER_IMAGE ?= alexfalkowski/$(IMAGE)
+
 # Build docker image.
 build-docker:
-	docker build -f Dockerfile -t alexfalkowski/$(IMAGE):$(VERSION) ..
+	@docker build -f Dockerfile -t $(DOCKER_IMAGE):$(VERSION) -t $(DOCKER_IMAGE) ..
 
-# Push built docker image.
+# Push docker image.
 push-docker:
-	docker build -f Dockerfile -t alexfalkowski/$(IMAGE):$(VERSION) -t alexfalkowski/$(IMAGE) --push ..
+	@docker push $(DOCKER_IMAGE):$(VERSION)
+	@docker push $(DOCKER_IMAGE)
+
+# Build and scan docker image.
+test-docker: build-docker trivy-docker
+
+# Scan docker image with Trivy.
+trivy-docker:
+	@trivy image --scanners vuln --pkg-types os --ignore-unfixed --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --exit-code 1 --severity CRITICAL $(DOCKER_IMAGE):$(VERSION)
+
+# Build, scan, and push docker image.
+release-docker: test-docker push-docker
 
 # Build platform docker image.
 build-platform-docker:
-	docker build --platform linux/$(platform) -f Dockerfile -t alexfalkowski/$(IMAGE):$(VERSION).$(platform) ..
+	@docker build --platform linux/$(platform) -f Dockerfile -t $(DOCKER_IMAGE):$(VERSION).$(platform) ..
 
-# Push built platform docker image.
+# Push platform docker image.
 push-platform-docker:
-	docker build --platform linux/$(platform) -f Dockerfile -t alexfalkowski/$(IMAGE):$(VERSION).$(platform) --push ..
+	@docker push $(DOCKER_IMAGE):$(VERSION).$(platform)
+
+# Build and scan platform docker image.
+test-platform-docker: build-platform-docker trivy-platform-docker
+
+# Scan platform docker image with Trivy.
+trivy-platform-docker:
+	@trivy image --scanners vuln --pkg-types os --ignore-unfixed --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --exit-code 1 --severity CRITICAL $(DOCKER_IMAGE):$(VERSION).$(platform)
+
+# Build, scan, and push platform docker image.
+release-platform-docker: test-platform-docker push-platform-docker
 
 manifest-platform-version-docker:
-	docker manifest create alexfalkowski/$(IMAGE):$(VERSION) --amend alexfalkowski/$(IMAGE):$(VERSION).amd64 --amend alexfalkowski/$(IMAGE):$(VERSION).arm64
-	docker manifest push alexfalkowski/$(IMAGE):$(VERSION)
+	@docker manifest create $(DOCKER_IMAGE):$(VERSION) --amend $(DOCKER_IMAGE):$(VERSION).amd64 --amend $(DOCKER_IMAGE):$(VERSION).arm64
+	@docker manifest push $(DOCKER_IMAGE):$(VERSION)
 
 manifest-platform-latest-docker:
-	docker manifest create alexfalkowski/$(IMAGE) --amend alexfalkowski/$(IMAGE):$(VERSION).amd64 --amend alexfalkowski/$(IMAGE):$(VERSION).arm64
-	docker manifest push alexfalkowski/$(IMAGE)
+	@docker manifest create $(DOCKER_IMAGE) --amend $(DOCKER_IMAGE):$(VERSION).amd64 --amend $(DOCKER_IMAGE):$(VERSION).arm64
+	@docker manifest push $(DOCKER_IMAGE)
 
 # Create a platform manifest.
 manifest-platform-docker: manifest-platform-version-docker manifest-platform-latest-docker
 
 # Lint docker image.
 lint-docker:
-	hadolint Dockerfile
+	@hadolint Dockerfile


### PR DESCRIPTION
## What

- Split image build, scan, push, and release flows in `make/docker.mk`.
- Add Trivy image scans to `test-docker`, `release-docker`, `test-platform-docker`, and `release-platform-docker`.
- Update CircleCI publish jobs to use the scan-before-push platform release target.
- Refresh README and AGENTS command guidance for the new Docker target flow.

## Why

- Keeps push targets focused on publishing already-built images while giving maintainers explicit test and release targets.
- Ensures master image publishing runs the same Trivy image verification that maintainers can run locally.
- Makes the Docker image workflow easier to read from the single shared make fragment.

## Testing

- `make lint` - passed
- `ruby -e 'require "yaml"; YAML.load_file(".circleci/config.yml"); YAML.load_file(".circleci/continue_config.yml"); puts "yaml ok"'` - passed
- `make -C go -n release-docker` - passed
- `make -C go -n platform=amd64 release-platform-docker manifest-platform-docker` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
