### PR TITLE
feat(docker): install trivy in tool image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,4 +8,5 @@ COPY scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
 COPY docker/scripts/install-image-tool.d/ /usr/local/lib/install-image-tool/
 RUN chmod +x /usr/local/bin/install-image-tool \
   && install-image-tool hadolint 2.14.0 \
-  && install-image-tool shellcheck 0.11.0
+  && install-image-tool shellcheck 0.11.0 \
+  && install-image-tool trivy 0.71.0

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=docker
-VERSION:=3.12
+VERSION:=3.13
 
 include ../make/docker.mk


### PR DESCRIPTION
## What

- Install Trivy 0.71.0 in the `alexfalkowski/docker` image alongside hadolint and shellcheck.
- Bump the image version from 3.12 to 3.13.
- Leave CircleCI executor tags on 3.12 until the new image has been published.

## Why

- The image needs Trivy available before CI can run image scan targets from this repository.
- Publishing a new docker image first keeps the later CI target changes from depending on an image tag that does not exist yet.

## Testing

- `make lint` - passed
- `make -C docker lint-docker` - passed
- `make -C docker -n build-docker` - passed
- `make -C docker -n platform=amd64 build-platform-docker` - passed
- `git diff --check` - passed
- Docker build was not run locally; validation was limited to linting and Make target dry-runs.

AI-assisted-by: [Codex](https://openai.com/codex/)
