### PR TITLE
docs(readme): clarify image and stack operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,9 @@ Docker images plus a `compose.yml` local dependency stack.
 ## Commands
 
 - `make lint`: lint Dockerfiles and shell scripts.
-- `make -C <dir> build-docker` / `test-docker` / `release-docker`: build, build+scan, or build+scan+push one image.
-- `make -C <dir> platform=amd64 build-platform-docker` / `test-platform-docker` / `release-platform-docker`: build, build+scan, or build+scan+push a platform image.
-- `make -C <dir> manifest-platform-docker`: publish the multi-arch manifests.
+- `make -C <dir> build-docker` / `test-docker` / `release-docker`: build, build+scan, or build+scan+push the versioned and unqualified `latest` tags for one image.
+- `make -C <dir> platform=amd64 build-platform-docker` / `test-platform-docker` / `release-platform-docker`: build, build+scan, or build+scan+push one versioned platform image tag.
+- `make -C <dir> manifest-platform-docker`: publish the versioned and unqualified `latest` multi-arch manifests.
 - `make docker-pull`, `make start`, `make stop`, `make logs service=<name>`: manage compose services.
 
 ## Rules
@@ -39,7 +39,7 @@ Docker images plus a `compose.yml` local dependency stack.
   1. First update only `root/` and bump `root/Makefile`'s `VERSION`; use a minor bump unless the change alters the root image contract in a major-version-worthy way, including major upgrades to dependencies shipped by the root image.
   2. After the new root image is published, update the Dockerfiles that depend on `alexfalkowski/root` and bump each dependent image `VERSION` in a separate change. If root had a major bump, dependents get a major bump; otherwise dependents get a minor bump.
 - Keep `.dockerignore` current when adding large or sensitive top-level paths.
-- Dockerfiles call `install-image-tool <tool> <version>` and `install-go-tool <module> <version>`; run `clean-go` after Go tool installs.
+- Dockerfiles call `install-image-tool <tool> <version>` and `install-go-tool <module> <version>`; run `clean-go` after Go tool installs. `install-image-tool` sources `/usr/local/lib/install-image-tool/<tool>` from a temporary directory with the bare version as `$1`; snippets should use the helper functions in `scripts/install-image-tool` for architecture selection, downloads, checksum verification, release tags, and binary installs.
 - Hadolint suppressions live in each image directory's `.hadolint.yaml`; there is no top-level hadolint config.
 - `release/` installs `gh`, `goreleaser`, and `uplift`, and copies `release/deploy`, `release/package`, `release/version`, and `release/.uplift.yml`.
 - `release/.uplift.yml` uses release commits shaped like `chore(release): $VERSION [ci skip]`.
@@ -49,6 +49,6 @@ Docker images plus a `compose.yml` local dependency stack.
 - `.gitmodules` uses the SSH URL `git@github.com:alexfalkowski/bin.git`.
 - Push, release, and manifest targets require DockerHub credentials.
 - `scripts/compose` prefers `podman compose` over `docker compose`.
-- `make clean` is destructive: it prunes all unused Docker or Podman images.
+- `make clean` is destructive: `scripts/clean` runs `image prune -a -f`, preferring Podman when `podman` is in `PATH` and falling back to Docker.
 - Mutable base image tags are intentional in this repository; do not flag tag-based `FROM` lines as review findings unless asked to make builds digest-pinned.
 - The images intentionally allow root-level operations where needed, including for tools such as `mkcert`; do not flag the root/sudo model as a review finding unless the task is specifically about hardening runtime privileges.

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,6 @@ stop:
 logs:
 	@scripts/compose -f compose.yml logs -f $(service)
 
-# Clean all unused docker images.
+# Clean unused Podman or Docker images.
 clean:
 	@scripts/clean

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ make -C go build-docker
 make -C go test-docker
 ```
 
-Push one image after a successful local build and scan:
+Push the versioned and unqualified `latest` image tags after a successful local
+build and scan:
 
 ```sh
 make -C go release-docker
@@ -95,7 +96,8 @@ make -C go platform=amd64 build-platform-docker
 make -C go platform=amd64 test-platform-docker
 ```
 
-Publish one platform image and then publish the multi-arch manifests:
+Publish one platform image and then publish the versioned and unqualified
+`latest` multi-arch manifests:
 
 ```sh
 make -C go platform=amd64 release-platform-docker
@@ -133,9 +135,35 @@ upgrades to dependencies shipped by the root image.
 The repository root is the Docker build context. Keep `.dockerignore` current
 when adding large or sensitive top-level paths.
 
+Dockerfiles install pinned archive tools with
+`install-image-tool <tool> <version>`. Put shared installer snippets in
+`scripts/install-image-tool.d/` and image-specific snippets in
+`<image>/scripts/install-image-tool.d/`; the snippet name is the tool name and
+receives the bare version as `$1`. Snippets run from a temporary directory and
+can use the helper functions from `scripts/install-image-tool` for architecture
+selection, downloads, checksum verification, release tags, and binary installs.
+Install pinned Go module tools with `install-go-tool <module> <version>`, which
+adds the `v` prefix for `go install`. Run `clean-go` after Go tool installs to
+remove Go build caches, module cache, `go/pkg`, and `.cache`.
+
+The `go/` image sets `GOEXPERIMENT=jsonv2` globally. Downstream projects that
+need default Go experiment behavior should override it for that command, for
+example `GOEXPERIMENT= go test ./...`.
+
 The `release/` image contains the `version`, `package`, and `deploy` helper
-commands. Read those scripts before using them locally; they can create tags,
-publish releases, clone over SSH, and raise remote changes.
+commands. They share `APP_VERSION_FILE`, defaulting to
+`/tmp/workspace/release-version.txt`, and expect to run from the repository
+being released.
+
+| Command | Behavior |
+| --- | --- |
+| `version` | Runs `uplift release --skip-changelog --config-dir /etc/uplift`, removes any stale version file first, and writes the new tag to `APP_VERSION_FILE` only when a new tag points at `HEAD`. |
+| `package` | Runs `goreleaser release` only when the working tree contains a GoReleaser config outside `vendor/` and `APP_VERSION_FILE` is non-empty. Otherwise it exits without publishing. |
+| `deploy` | Runs only when the repository contains `.cd` and `APP_VERSION_FILE` exists. It derives the app name from the current directory, clones `alexfalkowski/infraops` over SSH, bumps the released app version, and raises the infraops change through `make ready`. |
+
+Use the release helpers only in an authenticated release environment. They can
+create tags, publish releases, clone over SSH, push branches, and raise remote
+changes.
 
 ## 🧱 Local Dependencies
 
@@ -152,13 +180,50 @@ make stop
 
 Useful local entry points:
 
-- Postgres: `postgresql://test:test@localhost:5432/postgres`
-- Vault: `http://127.0.0.1:8200` with token `vault-plaintext-root-token`
-- Grafana: `http://127.0.0.1:10000`
-- OTLP: gRPC `127.0.0.1:4317`, HTTP `127.0.0.1:4318`
+| Service | Local endpoint | Use |
+| --- | --- | --- |
+| Postgres | `postgresql://test:test@localhost:5432/postgres` | Application database. |
+| Valkey/Redis | `redis://127.0.0.1:6379` | Redis-compatible cache or queue dependency. |
+| AWS emulator | `http://127.0.0.1:4566` | Local S3, SQS, and SSM. |
+| Vault | `http://127.0.0.1:8200` | Development Vault with token `vault-plaintext-root-token`. |
+| Prometheus | `http://127.0.0.1:9090` | Local metrics scraping and query UI. |
+| Mimir | `http://127.0.0.1:9009` | Prometheus remote-write backend. |
+| Loki | `http://127.0.0.1:3100` | OTLP log backend. |
+| Memcached | `127.0.0.1:11211` | Tempo query-frontend cache. |
+| Tempo | `http://127.0.0.1:3200` | Trace backend and query API. |
+| OTLP collector | gRPC `127.0.0.1:4317`, HTTP `127.0.0.1:4318` | Metrics, logs, and traces ingest. |
+| Grafana | `http://127.0.0.1:10000` | Dashboard UI. |
+| Status | `http://127.0.0.1:15000`, debug `http://127.0.0.1:15001` | Example service scraped by Prometheus. |
+| Flipt | `http://127.0.0.1:8080`, `127.0.0.1:9000` | Feature flag service APIs. |
 
 Most compose services do not declare named volumes, so treat their data as
-disposable. Prometheus is the exception and uses `prometheus_data`.
+disposable. Prometheus is the exception and uses `prometheus_data` for its
+local TSDB. Mimir, Loki, and Tempo use container-local filesystem storage in
+this stack, so remote-written metrics, logs, and traces are disposable when
+their containers are recreated unless you add storage for them.
+
+Observability flow:
+
+- Prometheus scrapes `prometheus` and `status`, then remote-writes samples to
+  Mimir.
+- The OpenTelemetry collector receives OTLP metrics, logs, and traces, then
+  sends metrics to Mimir, logs to Loki, and traces to Tempo.
+- Tempo generates service graph and span metrics, then remote-writes them back
+  to Prometheus.
+
+Grafana is not provisioned with datasources or dashboards by `compose.yml`.
+Create datasources manually before importing dashboards from `grafana/`:
+
+| Datasource | Type | URL from Grafana |
+| --- | --- | --- |
+| `prometheus` | Prometheus | `http://prometheus:9090` |
+| `loki` | Loki | `http://loki:3100` |
+| `tempo` | Tempo | `http://tempo:3200` |
+
+The bundled service, Go metrics, and Prometheus dashboards expect the
+`prometheus` datasource. `grafana/alertmanager.json` requires an Alertmanager
+service and Prometheus scrape target, which this compose stack does not start by
+default.
 
 For exact services, ports, images, and mounted config, read `compose.yml`.
 For dashboard imports and observability config, start with `grafana/`,
@@ -167,8 +232,9 @@ For dashboard imports and observability config, start with `grafana/`,
 ## 🧹 Cleanup
 
 > [!CAUTION]
-> `make clean` is destructive: it prunes unused images from the selected Docker
-> or Podman engine.
+> `make clean` is destructive: it runs `image prune -a -f` through
+> `scripts/clean`, using Podman when `podman` is in `PATH` and Docker
+> otherwise.
 
 ```sh
 make clean


### PR DESCRIPTION
## What

- Clarify image release targets so the versioned and `latest` tag and manifest effects are visible before maintainers run publish commands.
- Add maintainer-facing notes for the image install-helper contract, the Go image `GOEXPERIMENT=jsonv2` setting, and the release helper command gates and side effects.
- Expand the local dependency guidance with exposed endpoints, observability data flow and persistence boundaries, Grafana datasource setup, and Podman-first cleanup behavior.

## Why

- These behaviors were encoded in Make targets, shell helpers, Dockerfiles, and compose configuration, which made release, cleanup, image-maintenance, and local-stack workflows easy to misread from the README alone.
- Making the operational contracts explicit reduces the chance of publishing the wrong image tag, pruning the wrong local engine, adding broken installer snippets, or opening Grafana dashboards without the required datasources.

## Testing

- `gmake lint` - passed
- `gmake help` - passed
- `gmake -C go -n release-docker manifest-platform-docker` - passed
- `git diff --check` - passed
