### PR TITLE
docs(readme): trim repository guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,11 @@
 Docker images published under `docker.io/alexfalkowski/*`, plus a
 `compose.yml` stack for local dependencies used across projects.
 
-The repository is intentionally Make-driven. Use `make help` as the source of
-truth for root, local-stack, and shared git targets. Image build targets are
-shared by the image directories and documented below.
+The repository is Make-driven. Use `make help` for the current command list;
+Dockerfiles and image `Makefile`s are the source of truth for exact tool and
+image versions.
 
 ## 🗺️ Map
-
-Image directories:
 
 | Directory | Image | Purpose |
 | --- | --- | --- |
@@ -24,40 +22,22 @@ Image directories:
 | `release/` | `alexfalkowski/release` | Release automation tooling and helper commands. |
 | `ruby/` | `alexfalkowski/ruby` | Ruby project CI tooling. |
 
-Image command surface:
+Useful paths:
 
-| Image | Notable tools and contracts |
-| --- | --- |
-| `root` | Ruby, Bundler, Go, Docker CLI/buildx/compose, Git, jq, Make, SSH, and the default `circleci` user used by dependent images. |
-| `docker` | `hadolint`, `shellcheck`, and `trivy` for Dockerfile, shell, and image-security checks. |
-| `go` | `buf`, `codecov`, `dockerize`, `fieldalignment`, `gocovmerge`, `golangci-lint`, `govulncheck`, `gotestsum`, `gsa`, `hadolint`, `mkcert`, `scc`, `shellcheck`, and `trivy`; sets `GOEXPERIMENT=jsonv2`. |
-| `k8s` | `doctl`, `kubectl`, `kubescape`, `pulumi`, `vegeta`, and `kube-score`. |
-| `release` | `gh`, `goreleaser`, `uplift`, `bump`, and the `version`, `package`, and `deploy` helpers. |
-| `ruby` | `buf`, `codecov`, `dockerize`, `hadolint`, `mkcert`, `scc`, `shellcheck`, and `trivy`. |
-
-Dockerfiles are the source of truth for exact pinned tool versions.
-
-Other useful paths:
-
-- `make/docker.mk`: shared image build, scan, push, and manifest targets.
-- `scripts/`: compose wrapper, lint wrapper, cleanup, and install helpers.
-- `scripts/install-image-tool.d/`: shared image install snippets.
-- `<image>/scripts/install-image-tool.d/`: image-specific install snippets.
-- `compose.yml`: local dependency stack.
-- `grafana/`, `otelcol/`, `prometheus/`, `status/`: config mounted by the
-  compose stack.
-- `.circleci/`: path-filtered image build and publish workflows.
+- `make/docker.mk`: shared build, scan, push, and manifest targets.
+- `scripts/`: compose, lint, cleanup, and install helpers.
+- `scripts/install-image-tool.d/`: shared installer snippets.
+- `<image>/scripts/install-image-tool.d/`: image-specific installer snippets.
+- `compose.yml`, `grafana/`, `otelcol/`, `prometheus/`, `status/`: local
+  dependency and observability stack.
 
 ## ✅ Setup
 
 > [!IMPORTANT]
 > Initialize the shared `bin/` submodule before running repository targets.
 
-Use GNU Make 4 or newer. On macOS, use `gmake` if Homebrew installed GNU Make
-under that name; `/usr/bin/make` 3.81 cannot parse the shared `bin/` make
-fragments.
-
-Initialize the shared `bin/` submodule before running repository targets:
+Use GNU Make 4 or newer. On macOS, use `gmake`; `/usr/bin/make` 3.81 cannot
+parse the shared `bin/` make fragments.
 
 ```sh
 git submodule sync
@@ -67,13 +47,7 @@ git submodule update --init
 The submodule URL is `git@github.com:alexfalkowski/bin.git`, so fresh
 checkouts need GitHub SSH access.
 
-Common local tools:
-
-- `docker`: image builds, scans, pushes, and manifests.
-- `podman` or `docker`: local compose stack and image cleanup.
-- `ruby`: shared `bin/` make fragments.
-- `hadolint` and `shellcheck`: `make lint`.
-- `trivy`: image scan targets.
+Common local tools are Docker or Podman, Ruby, Hadolint, ShellCheck, and Trivy.
 
 ## 🛠️ Commands
 
@@ -97,9 +71,6 @@ Discover targets:
 make help
 ```
 
-Image directories do not expose their own `help` target; use the examples below
-for the shared image target names.
-
 Lint:
 
 ```sh
@@ -113,42 +84,24 @@ make -C go build-docker
 make -C go test-docker
 ```
 
-Image targets tag `DOCKER_IMAGE`, which defaults to `alexfalkowski/<image>`.
-Override it when building a fork or a local registry image:
-
-```sh
-make -C go DOCKER_IMAGE=example/go build-docker
-```
-
-Push the versioned and unqualified `latest` image tags after a successful local
-build and scan:
+Build, scan, push, and publish manifests:
 
 ```sh
 make -C go release-docker
-```
-
-Build or scan one platform image:
-
-```sh
-make -C go platform=amd64 build-platform-docker
-make -C go platform=amd64 test-platform-docker
-```
-
-Publish one platform image and then publish the versioned and unqualified
-`latest` multi-arch manifests:
-
-```sh
 make -C go platform=amd64 release-platform-docker
 make -C go platform=arm64 release-platform-docker
 make -C go manifest-platform-docker
 ```
 
+Override `DOCKER_IMAGE` when building a fork or local registry image:
+
+```sh
+make -C go DOCKER_IMAGE=example/go build-docker
+```
+
 > [!WARNING]
 > Push, release, and manifest targets publish to DockerHub and require
 > DockerHub credentials.
-
-Image scans are implemented in `make/docker.mk` and currently run Trivy
-OS-package vulnerability checks.
 
 ## 🧭 Maintainer Notes
 
@@ -156,63 +109,33 @@ Image `Makefile`s set `IMAGE` and `VERSION`, then include `../make/docker.mk`.
 `VERSION` values are maintainer-managed; do not bump them unless the change is
 part of a release.
 
-> [!IMPORTANT]
-> Root image updates are staged so dependent images can move after the new root
-> image is published.
+Routine Docker dependency maintenance is handled by the shared
+`update-docker-dep` workflow in
+[`alexfalkowski/scripts`](https://github.com/alexfalkowski/scripts). Keep local
+changes focused on repository-specific image contracts, installer snippets, and
+validation.
 
 Root image updates are staged:
 
 1. Update only `root/` and bump `root/Makefile`'s `VERSION`.
-2. After that root image is published, update dependent Dockerfiles that use
+2. After the root image is published, update dependent Dockerfiles that use
    `alexfalkowski/root` and bump their versions in a separate change.
 
 Use a minor bump for ordinary root image changes. Use a major bump when the
 root image contract changes in a major-version-worthy way, including major
-upgrades to dependencies shipped by the root image.
-If root gets a major bump, dependent images get major bumps when they move to
-the new root. Otherwise dependent images get minor bumps.
-
-The root image contract is the runtime surface inherited by dependent images:
-the Ruby slim Debian base, Go toolchain and `GOPATH`/`PATH` setup, Docker CLI
-tooling, RubyGems and Bundler, the passwordless-sudo `circleci` user, and the
-default `/home/circleci/` working directory. It also includes the native build
-toolchain and Debian development packages installed by `root/Dockerfile`, such
-as `build-essential`, `clang`, `pkg-config`, and library headers used by
-downstream builds. Treat changes to those surfaces as compatibility changes for
-root and dependent images.
+upgrades to dependencies shipped by the root image. If root gets a major bump,
+dependent images get major bumps when they move to the new root; otherwise they
+get minor bumps.
 
 The repository root is the Docker build context. Keep `.dockerignore` current
 when adding large or sensitive top-level paths.
 
-Dockerfiles install pinned archive tools with
-`install-image-tool <tool> <version>`. Put shared installer snippets in
-`scripts/install-image-tool.d/` and image-specific snippets in
-`<image>/scripts/install-image-tool.d/`; the snippet name is the tool name and
-receives the bare version as `$1`. Snippets run from a temporary directory and
-can use the helper functions from `scripts/install-image-tool` for architecture
-selection, downloads, checksum verification, release tags, and binary installs.
-Install pinned Go module tools with `install-go-tool <module> <version>`, which
-adds the `v` prefix for `go install`. Run `clean-go` after Go tool installs to
-remove Go build caches, module cache, `go/pkg`, and `.cache`.
-
-The `go/` image sets `GOEXPERIMENT=jsonv2` globally. Downstream projects that
-need default Go experiment behavior should override it for that command, for
-example `GOEXPERIMENT= go test ./...`.
-
-The `release/` image contains the `version`, `package`, and `deploy` helper
-commands. They share `APP_VERSION_FILE`, defaulting to
-`/tmp/workspace/release-version.txt`, and expect to run from the repository
-being released.
-
-| Command | Behavior |
-| --- | --- |
-| `version` | Runs `uplift release --skip-changelog --config-dir /etc/uplift`, removes any stale version file first, and writes the new tag to `APP_VERSION_FILE` only when a new tag points at `HEAD`. |
-| `package` | Runs `goreleaser release` only when the working tree contains a path whose name includes `goreleaser` outside `vendor/` and `APP_VERSION_FILE` is non-empty. Otherwise it exits without publishing. |
-| `deploy` | Runs only when the repository contains `.cd` and `APP_VERSION_FILE` exists. It expects the version file to contain the tag written by `version`, derives the app name from the current directory, clones `alexfalkowski/infraops` over SSH into `./infraops`, bumps the released app version, and raises the infraops change through `make ready`. Failed runs can leave `./infraops` behind; remove it before rerunning. |
-
-Use the release helpers only in an authenticated release environment. They can
-create tags, publish releases, clone over SSH, push branches, and raise remote
-changes.
+Installer snippets run through `install-image-tool <tool> <version>` and
+receive the bare version as `$1`. Use helper functions from
+`scripts/install-image-tool` for architecture selection, downloads, checksum
+verification, release tags, and binary installs. Go module tools are installed
+with `install-go-tool <module> <version>`; run `clean-go` after Go tool
+installs.
 
 ## 🧱 Local Dependencies
 
@@ -231,60 +154,28 @@ make stop
 services to become ready. Check `make logs service=<name>` or the local
 endpoints before running dependent applications.
 
-Useful local entry points:
+Useful local endpoints:
 
-| Service | Local endpoint | Use |
-| --- | --- | --- |
-| Postgres | `postgresql://test:test@localhost:5432/postgres` | Application database. |
-| Valkey/Redis | `redis://127.0.0.1:6379` | Redis-compatible cache or queue dependency. |
-| AWS emulator | `http://127.0.0.1:4566` | Local S3, SQS, and SSM. |
-| Vault | `http://127.0.0.1:8200` | Development Vault with token `vault-plaintext-root-token`. |
-| Prometheus | `http://127.0.0.1:9090` | Local metrics scraping and query UI. |
-| Mimir | `http://127.0.0.1:9009` | Prometheus remote-write backend. |
-| Loki | `http://127.0.0.1:3100` | OTLP log backend. |
-| Memcached | `127.0.0.1:11211` | Tempo query-frontend cache. |
-| Tempo | `http://127.0.0.1:3200` | Trace backend and query API. |
-| OTLP collector | gRPC `127.0.0.1:4317`, HTTP `127.0.0.1:4318` | Metrics, logs, and traces ingest. |
-| Grafana | `http://127.0.0.1:10000` | Dashboard UI. |
-| Status | `http://127.0.0.1:15000`, debug `http://127.0.0.1:15001` | Example service scraped by Prometheus. |
-| Flipt | `http://127.0.0.1:8080`, `127.0.0.1:9000` | Feature flag service APIs. |
+| Service | Local endpoint |
+| --- | --- |
+| Postgres | `postgresql://test:test@localhost:5432/postgres` |
+| Valkey/Redis | `redis://127.0.0.1:6379` |
+| AWS emulator | `http://127.0.0.1:4566` |
+| Vault | `http://127.0.0.1:8200` |
+| Prometheus | `http://127.0.0.1:9090` |
+| Mimir | `http://127.0.0.1:9009` |
+| Loki | `http://127.0.0.1:3100` |
+| Memcached | `127.0.0.1:11211` |
+| Tempo | `http://127.0.0.1:3200` |
+| OTLP collector | gRPC `127.0.0.1:4317`, HTTP `127.0.0.1:4318` |
+| Grafana | `http://127.0.0.1:10000` |
+| Status | `http://127.0.0.1:15000`, debug `http://127.0.0.1:15001` |
+| Flipt | `http://127.0.0.1:8080`, `127.0.0.1:9000` |
 
-Most compose services do not declare named volumes, so treat their data as
-disposable. Prometheus is the exception and uses `prometheus_data` for its
-local TSDB. Mimir, Loki, and Tempo use container-local filesystem storage in
-this stack, so remote-written metrics, logs, and traces are disposable when
-their containers are recreated unless you add storage for them.
+Most compose services use disposable container-local storage. Prometheus is the
+exception and uses the `prometheus_data` volume.
 
-Observability flow:
-
-- Prometheus scrapes `prometheus` and `status`, then remote-writes samples to
-  Mimir.
-- The OpenTelemetry collector receives OTLP metrics, logs, and traces, then
-  sends metrics to Mimir, logs to Loki, and traces to Tempo.
-- The bundled `status` service exposes Prometheus metrics and sends traces
-  directly to Tempo. Use the collector endpoints when testing collector ingest
-  from external clients.
-- Tempo generates service graph and span metrics, then remote-writes them back
-  to Prometheus.
-
-Grafana is not provisioned with datasources or dashboards by `compose.yml`.
-It uses the upstream Grafana login defaults unless you override them locally;
-for the default image, log in with `admin` / `admin`. Create datasources
-manually before importing dashboards from `grafana/`:
-
-| Datasource | Type | URL from Grafana |
-| --- | --- | --- |
-| `prometheus` | Prometheus | `http://prometheus:9090` |
-| `loki` | Loki | `http://loki:3100` |
-| `tempo` | Tempo | `http://tempo:3200` |
-
-The bundled service, Go metrics, and Prometheus dashboards expect the
-`prometheus` datasource. `grafana/alertmanager.json` requires an Alertmanager
-service and Prometheus scrape target, which this compose stack does not start by
-default.
-
-External applications should send telemetry to the OpenTelemetry collector, not
-directly to Mimir, Loki, or Tempo. For OTLP/HTTP clients:
+External applications should send telemetry to the OpenTelemetry collector:
 
 ```sh
 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
@@ -292,10 +183,8 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318 \
 <app command>
 ```
 
-Use `127.0.0.1:4317` for OTLP/gRPC clients.
-
-For exact services, ports, images, and mounted config, read `compose.yml`.
-For dashboard imports and observability config, start with `grafana/`,
+Use `127.0.0.1:4317` for OTLP/gRPC clients. For exact services, ports, images,
+mounted config, and dashboards, read `compose.yml`, `grafana/`,
 `otelcol/config.yml`, and `prometheus/config.yml`.
 
 ## 🧹 Cleanup
@@ -311,15 +200,13 @@ make clean
 
 ## 🔁 CI
 
-CircleCI uses path filtering:
-
-- `.circleci/config.yml` maps changed paths to image pipeline parameters.
-- `.circleci/continue_config.yml` defines the image build, publish, manifest,
-  sync, and release jobs.
+CircleCI uses path filtering from `.circleci/config.yml`; the continued config
+defines image build, publish, manifest, sync, and release jobs.
 
 On `master`, CI publishes platform images and manifests with the CircleCI
-`docker` context. The `version` job uses the `gh` context. On non-`master`
-branches, CI builds the changed images and then runs `make sync push`.
+`docker` context. On non-`master` branches, CI builds changed images and runs
+`make sync push`.
+
 Stack-only changes to `compose.yml`, `grafana/`, `otelcol/`, `prometheus/`, or
 `status/` are outside the image path filters, so validate them locally with
-`make start`, `make logs service=<name>`, and the relevant local endpoints.
+`make start`, `make logs service=<name>`, and the relevant endpoints.


### PR DESCRIPTION
## What

- Shorten the repository README so it focuses on orientation, setup, core image commands, and local dependency entry points.
- Replace long tool and maintainer inventories with concise pointers to Dockerfiles, image Makefiles, installer snippets, and compose configuration.
- Point routine Docker dependency maintenance at the shared `update-docker-dep` workflow in `alexfalkowski/scripts`.

## Why

- Keeps the README useful as a first-use guide without duplicating details already owned by Dockerfiles, Make targets, CI config, and shared maintenance scripts.
- Reduces maintainer noise while preserving the non-obvious root image staging, DockerHub publishing, local stack, and cleanup warnings.

## Testing

- `gmake help` - passed
- `git diff --check -- README.md` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
