### PR TITLE
feat(release): check packaging config before publishing

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=release
-VERSION:=8.15
+VERSION:=8.16
 
 include ../make/docker.mk

--- a/release/package
+++ b/release/package
@@ -7,5 +7,6 @@ readonly releaser=$(find . -name "*goreleaser*" -not -path "*vendor*")
 readonly version_file="${APP_VERSION_FILE:-/tmp/workspace/release-version.txt}"
 
 if [[ -n "$releaser" && -s "$version_file" ]]; then
+  goreleaser check "$releaser"
   goreleaser release
 fi


### PR DESCRIPTION
## What

- Validate the discovered GoReleaser config before running the packaging publish step.
- Keep the existing packaging gate: the helper still runs only when a GoReleaser config exists and the release version file is present.
- Bump the release image version from `8.15` to `8.16` for the helper behavior change.

## Why

- A malformed GoReleaser config should fail before the release helper starts publishing.
- Putting the check in the release image helper validates the owning command path for every repository that uses this packaging image, instead of requiring service-local CI checks.

## Testing

- `gmake lint` - passed
- `git diff --check` - passed
- `gmake -C release -n build-docker` - passed, showing `alexfalkowski/release:8.16`
- `release/package` with a fake successful `goreleaser` - passed, recorded `check ./.goreleaser.yml` before `release`
- `release/package` with a fake failing `goreleaser check` - failed as expected and did not call `release`
