### PR TITLE
feat(release): pin package config lookup to repo root

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -1,4 +1,4 @@
 IMAGE:=release
-VERSION:=8.17
+VERSION:=8.18
 
 include ../make/docker.mk

--- a/release/package
+++ b/release/package
@@ -3,10 +3,10 @@
 
 set -eo pipefail
 
-readonly releaser=$(find . -name "*goreleaser*" -not -path "*vendor*")
+readonly releaser="./.goreleaser.yml"
 readonly version_file="${APP_VERSION_FILE:-/tmp/workspace/release-version.txt}"
 
-if [[ -n "$releaser" && -s "$version_file" ]]; then
+if [[ -f "$releaser" && -s "$version_file" ]]; then
   goreleaser check "$releaser"
   goreleaser release
 fi


### PR DESCRIPTION
## What

- Update the package command to check only `./.goreleaser.yml` from the repository root before invoking GoReleaser.
- Bump the release image version to `8.18` so downstream CI can consume the script fix.

## Why

- Prevent the package command from passing every `*goreleaser*` path in a checkout, including the `./bin` submodule config and installer snippets, to `goreleaser check`.
- Keep downstream repositories that run the command from their checkout root pointed at their own GoReleaser config.

## Testing

- `gmake lint` - passed
- `release/package` with a fake `goreleaser` and temporary version file - passed; verified `check ./.goreleaser.yml` and `release` invocations.
