### PR TITLE
docs(agents): prefer make command surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,8 @@ Docker images plus a `compose.yml` local dependency stack.
 ## Basics
 
 - Use GNU Make 4+. On macOS, use `gmake`; `/usr/bin/make` 3.81 cannot parse the shared `bin/` make fragments.
-- Initialize the required submodule with `git submodule sync && git submodule update --init`.
+- Initialize the required submodule before using shared targets; use
+  `make submodule` when the shared checkout is present.
 - Show targets with `make help` or `gmake help`.
 
 ## Map
@@ -32,7 +33,7 @@ Docker images plus a `compose.yml` local dependency stack.
 
 - Image `Makefile`s set `IMAGE` and `VERSION`, then include `../make/docker.mk`.
 - Image `VERSION` values are managed by the maintainer; do not bump them unless explicitly asked.
-- `make/docker.mk` builds from the repo root context with `docker build -f Dockerfile ... ..`.
+- `make/docker.mk` owns Docker build invocation from the repo root context.
 - Updating `root/` is a two-stage process driven by the maintainer:
   1. First update only `root/` and bump `root/Makefile`'s `VERSION`; use a minor bump unless the change alters the root image contract in a major-version-worthy way, including major upgrades to dependencies shipped by the root image.
   2. After the new root image is published, update the Dockerfiles that depend on `alexfalkowski/root` and bump each dependent image `VERSION` in a separate change. If root had a major bump, dependents get a major bump; otherwise dependents get a minor bump.


### PR DESCRIPTION
## What

- Update the `bin` submodule to the shared guidance that centralizes Makefile-first command policy.
- Clean up local `AGENTS.md` guidance so repository instructions prefer Make targets instead of direct tool commands.
- Remove stale-prone runtime, toolchain, dependency, or image version claims from local agent guidance where they belonged in source files or CI configuration.

## Why

- Keeps command guidance aligned with the shared `bin/AGENTS.md` policy and avoids copying ad hoc commands across repositories.
- Reduces stale local agent instructions by leaving changing versions and tool details in their authoritative files.

## Testing

- `git diff --check` - passed
- `zsh -lic 'make lint'` - passed
- Direct-command guidance scan - passed
- Exact-version guidance scan - passed; remaining matches are IP address literals, not dependency, toolchain, or image versions.

AI-assisted-by: [Codex](https://openai.com/codex/)
