### PR TITLE
build(bin): refresh shared tooling guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,6 @@ Docker images plus a `compose.yml` local dependency stack.
 
 ## Basics
 
-- Use GNU Make 4+. On macOS, use `gmake`; `/usr/bin/make` 3.81 cannot parse the shared `bin/` make fragments.
-- Initialize the required submodule before using shared targets; use
-  `make submodule` when the shared checkout is present.
 - Show targets with `make help` or `gmake help`.
 
 ## Map


### PR DESCRIPTION
## What

- Updates the `bin` submodule to the merged shared project-gap guidance changes.
- Removes local `AGENTS.md` exception text that is now covered by shared `bin/AGENTS.md`.

## Why

- Keeps downstream project-gap investigations focused on repository-specific issues instead of repeating shared workflow exceptions.
- Reduces duplicated maintainer guidance across repositories while preserving repo-specific notes.

## Testing

- `git diff --check` - passed
- `make help` - passed
- `make lint` - passed
