### PR TITLE
build(project): check compose stack config in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,14 @@ workflows:
             scripts/.* docker true
             docker/.* docker true
 
+            .circleci/.* stack true
+            Makefile stack true
+            compose.yml stack true
+            grafana/.* stack true
+            otelcol/.* stack true
+            prometheus/.* stack true
+            status/.* stack true
+
             .circleci/.* go true
             Makefile go true
             make/.* go true

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -4,6 +4,9 @@ parameters:
   docker:
     type: boolean
     default: false
+  stack:
+    type: boolean
+    default: false
   go:
     type: boolean
     default: false
@@ -49,6 +52,13 @@ jobs:
       - checkout-submodules
       - run: make lint
       - run: make trivy-repo
+    resource_class: arm.large
+  stack-config:
+    executor: docker
+    working_directory: ~/docker
+    steps:
+      - checkout-submodules
+      - run: make stack-config
     resource_class: arm.large
   sync:
     executor: release
@@ -410,6 +420,8 @@ workflows:
             - docker-push-amd64
             - docker-push-arm64
           filters: 'pipeline.parameters.docker and pipeline.git.branch == "master"'
+      - stack-config:
+          filters: 'pipeline.parameters.stack'
 
       - go-build-amd64:
           filters: 'pipeline.parameters.go and pipeline.git.branch != "master"'
@@ -498,6 +510,7 @@ workflows:
       - sync:
           requires:
             - lint
+            - stack-config
             - docker-build-amd64
             - docker-build-arm64
             - go-build-amd64
@@ -514,6 +527,7 @@ workflows:
       - wait-all:
           requires:
             - lint
+            - stack-config
             - sync
             - version
             - docker-build-amd64

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ lint:
 trivy-repo:
 	@$(BIN_ROOT)/build/sec/trivy-repo
 
+# Validate the local compose stack config.
+stack-config:
+	@scripts/compose -f compose.yml config --quiet
+
 # Pull latest containers, or one service with service=<name>.
 pull-latest:
 	@scripts/compose -f compose.yml pull $(service)


### PR DESCRIPTION
## What

- Add a `stack-config` Make target that validates `compose.yml` through the existing compose wrapper.
- Add path-filtering and a lightweight CircleCI job for local stack-only changes.

## Why

- The repository owns the local dependency and observability stack, but stack-only changes previously sat outside image path filters and relied on manual validation.
- The new preflight checks compose syntax without starting services, pulling images, or publishing artifacts.

## Testing

- `gmake stack-config` - passed.
- `gmake help` - passed and shows the new target.
