### PR TITLE
feat(root): install fixed debian security packages

### DIFF
--- a/root/Dockerfile
+++ b/root/Dockerfile
@@ -21,8 +21,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   libncurses-dev \
   libpq-dev \
   libreadline-dev \
+  libssh2-1t64 \
   libssl-dev \
   libyaml-dev \
+  linux-libc-dev \
   make \
   netcat-openbsd \
   openssh-client \

--- a/root/Makefile
+++ b/root/Makefile
@@ -1,5 +1,5 @@
 IMAGE:=root
-VERSION:=3.10
+VERSION:=3.11
 
 include ../bin/build/make/help.mak
 include ../make/docker.mk


### PR DESCRIPTION
## What

- Explicitly install the Debian packages that carry the fixed libssh2 and Linux libc headers in the base CI image.
- Bump the base image version from 3.10 to 3.11 for the staged root-image release.
- Keep dependent images on the current published base image; those should move to 3.11 in a separate follow-up after this image is published.

## Why

- Current image scans report critical Debian vulnerabilities for libssh2-1t64 and linux-libc-dev in images that inherit from the base CI image.
- Rebuilding the base image against current trixie-security repositories installs the fixed package versions and clears the critical OS vulnerability gate.

## Testing

- `make lint` - passed
- `make trivy-repo` - passed; repository vulnerability files were not present, and secret scanning reported no issues.
- `make -C root lint-docker` - passed
- `make -C root platform=amd64 test-platform-docker` - passed; Trivy reported 0 vulnerabilities for alexfalkowski/root:3.11.amd64.
- `make -C root platform=arm64 test-platform-docker` - passed; Trivy reported 0 vulnerabilities for alexfalkowski/root:3.11.arm64.
