### PR TITLE
feat(deps): use published base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.10
+FROM alexfalkowski/root:3.11
 
 USER root
 WORKDIR /usr/local/bin

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,5 +1,5 @@
 IMAGE:=docker
-VERSION:=3.15
+VERSION:=3.16
 
 include ../bin/build/make/help.mak
 include ../make/docker.mk

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.10
+FROM alexfalkowski/root:3.11
 
 USER root
 WORKDIR /usr/local/bin

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,5 +1,5 @@
 IMAGE:=go
-VERSION:=4.21
+VERSION:=4.22
 
 include ../bin/build/make/help.mak
 include ../make/docker.mk

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.10
+FROM alexfalkowski/root:3.11
 
 USER root
 WORKDIR /usr/local/bin

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1,5 +1,5 @@
 IMAGE:=k8s
-VERSION:=4.32
+VERSION:=4.33
 
 include ../bin/build/make/help.mak
 include ../make/docker.mk

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.10
+FROM alexfalkowski/root:3.11
 
 USER root
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,5 +1,5 @@
 IMAGE:=release
-VERSION:=8.18
+VERSION:=8.19
 
 include ../bin/build/make/help.mak
 include ../make/docker.mk

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.10
+FROM alexfalkowski/root:3.11
 
 USER root
 WORKDIR /usr/local/bin

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -1,5 +1,5 @@
 IMAGE:=ruby
-VERSION:=3.17
+VERSION:=3.18
 
 include ../bin/build/make/help.mak
 include ../make/docker.mk


### PR DESCRIPTION
## What

- Update the Docker, Go, Kubernetes, release, and Ruby CI images to inherit from `alexfalkowski/root:3.11`.
- Bump each dependent image version after the published base image minor release.
- Keep the root image version unchanged; this is the second-stage dependent image update after the base image was published.

## Why

- The published base image includes the Debian security fixes needed to clear inherited OS vulnerability findings in dependent images.
- Moving dependents to the new base image carries those fixes into the images CI builds and publishes.

## Testing

- `make lint` - passed
- `make trivy-repo` - passed; repository vulnerability files were not present, and secret scanning reported no issues.
- `make -C docker platform=amd64 test-platform-docker` - passed; built against published `alexfalkowski/root:3.11` and Trivy reported 0 vulnerabilities for `alexfalkowski/docker:3.16.amd64`.
- Full dependent image platform matrix was left to CI.
