### PR TITLE
build(ci): publish images only after version changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,11 +10,12 @@ workflows:
     jobs:
       - path_filtering/filter:
           mapping: |
-            .circleci/.* docker true
             Makefile docker true
+            .circleci/.* docker true
             make/.* docker true
             scripts/.* docker true
             docker/.* docker true
+            docker/Makefile docker_publish true
 
             .circleci/.* stack true
             Makefile stack true
@@ -24,34 +25,39 @@ workflows:
             prometheus/.* stack true
             status/.* stack true
 
-            .circleci/.* go true
             Makefile go true
+            .circleci/.* go true
             make/.* go true
             scripts/.* go true
             go/.* go true
+            go/Makefile go_publish true
 
-            .circleci/.* k8s true
             Makefile k8s true
+            .circleci/.* k8s true
             make/.* k8s true
             scripts/.* k8s true
             k8s/.* k8s true
+            k8s/Makefile k8s_publish true
 
-            .circleci/.* release true
             Makefile release true
+            .circleci/.* release true
             make/.* release true
             scripts/.* release true
             release/.* release true
+            release/Makefile release_publish true
 
-            .circleci/.* root true
             Makefile root true
+            .circleci/.* root true
             make/.* root true
             scripts/.* root true
             root/.* root true
+            root/Makefile root_publish true
 
-            .circleci/.* ruby true
             Makefile ruby true
+            .circleci/.* ruby true
             make/.* ruby true
             scripts/.* ruby true
             ruby/.* ruby true
+            ruby/Makefile ruby_publish true
           base-revision: origin/master
           resource_class: large

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -4,22 +4,40 @@ parameters:
   docker:
     type: boolean
     default: false
+  docker_publish:
+    type: boolean
+    default: false
   stack:
     type: boolean
     default: false
   go:
     type: boolean
     default: false
+  go_publish:
+    type: boolean
+    default: false
   k8s:
+    type: boolean
+    default: false
+  k8s_publish:
     type: boolean
     default: false
   release:
     type: boolean
     default: false
+  release_publish:
+    type: boolean
+    default: false
   root:
     type: boolean
     default: false
+  root_publish:
+    type: boolean
+    default: false
   ruby:
+    type: boolean
+    default: false
+  ruby_publish:
     type: boolean
     default: false
 
@@ -410,16 +428,16 @@ workflows:
           filters: 'pipeline.parameters.docker and pipeline.git.branch != "master"'
       - docker-push-amd64:
           context: docker
-          filters: 'pipeline.parameters.docker and pipeline.git.branch == "master"'
+          filters: 'pipeline.parameters.docker_publish and pipeline.git.branch == "master"'
       - docker-push-arm64:
           context: docker
-          filters: 'pipeline.parameters.docker and pipeline.git.branch == "master"'
+          filters: 'pipeline.parameters.docker_publish and pipeline.git.branch == "master"'
       - docker-manifest:
           context: docker
           requires:
             - docker-push-amd64
             - docker-push-arm64
-          filters: 'pipeline.parameters.docker and pipeline.git.branch == "master"'
+          filters: 'pipeline.parameters.docker_publish and pipeline.git.branch == "master"'
       - stack-config:
           filters: 'pipeline.parameters.stack'
 
@@ -429,16 +447,16 @@ workflows:
           filters: 'pipeline.parameters.go and pipeline.git.branch != "master"'
       - go-push-amd64:
           context: docker
-          filters: 'pipeline.parameters.go and pipeline.git.branch == "master"'
+          filters: 'pipeline.parameters.go_publish and pipeline.git.branch == "master"'
       - go-push-arm64:
           context: docker
-          filters: 'pipeline.parameters.go and pipeline.git.branch == "master"'
+          filters: 'pipeline.parameters.go_publish and pipeline.git.branch == "master"'
       - go-manifest:
           context: docker
           requires:
             - go-push-amd64
             - go-push-arm64
-          filters: 'pipeline.parameters.go and pipeline.git.branch == "master"'
+          filters: 'pipeline.parameters.go_publish and pipeline.git.branch == "master"'
 
       - k8s-build-amd64:
           filters: 'pipeline.parameters.k8s and pipeline.git.branch != "master"'
@@ -446,16 +464,16 @@ workflows:
           filters: 'pipeline.parameters.k8s and pipeline.git.branch != "master"'
       - k8s-push-amd64:
           context: docker
-          filters: 'pipeline.parameters.k8s and pipeline.git.branch == "master"'
+          filters: 'pipeline.parameters.k8s_publish and pipeline.git.branch == "master"'
       - k8s-push-arm64:
           context: docker
-          filters: 'pipeline.parameters.k8s and pipeline.git.branch == "master"'
+          filters: 'pipeline.parameters.k8s_publish and pipeline.git.branch == "master"'
       - k8s-manifest:
           context: docker
           requires:
             - k8s-push-amd64
             - k8s-push-arm64
-          filters: 'pipeline.parameters.k8s and pipeline.git.branch == "master"'
+          filters: 'pipeline.parameters.k8s_publish and pipeline.git.branch == "master"'
 
       - release-build-amd64:
           filters: 'pipeline.parameters.release and pipeline.git.branch != "master"'
@@ -463,16 +481,16 @@ workflows:
           filters: 'pipeline.parameters.release and pipeline.git.branch != "master"'
       - release-push-amd64:
           context: docker
-          filters: 'pipeline.parameters.release and pipeline.git.branch == "master"'
+          filters: 'pipeline.parameters.release_publish and pipeline.git.branch == "master"'
       - release-push-arm64:
           context: docker
-          filters: 'pipeline.parameters.release and pipeline.git.branch == "master"'
+          filters: 'pipeline.parameters.release_publish and pipeline.git.branch == "master"'
       - release-manifest:
           context: docker
           requires:
             - release-push-amd64
             - release-push-arm64
-          filters: 'pipeline.parameters.release and pipeline.git.branch == "master"'
+          filters: 'pipeline.parameters.release_publish and pipeline.git.branch == "master"'
 
       - root-build-amd64:
           filters: 'pipeline.parameters.root and pipeline.git.branch != "master"'
@@ -480,16 +498,16 @@ workflows:
           filters: 'pipeline.parameters.root and pipeline.git.branch != "master"'
       - root-push-amd64:
           context: docker
-          filters: 'pipeline.parameters.root and pipeline.git.branch == "master"'
+          filters: 'pipeline.parameters.root_publish and pipeline.git.branch == "master"'
       - root-push-arm64:
           context: docker
-          filters: 'pipeline.parameters.root and pipeline.git.branch == "master"'
+          filters: 'pipeline.parameters.root_publish and pipeline.git.branch == "master"'
       - root-manifest:
           context: docker
           requires:
             - root-push-amd64
             - root-push-arm64
-          filters: 'pipeline.parameters.root and pipeline.git.branch == "master"'
+          filters: 'pipeline.parameters.root_publish and pipeline.git.branch == "master"'
 
       - ruby-build-amd64:
           filters: 'pipeline.parameters.ruby and pipeline.git.branch != "master"'
@@ -497,16 +515,16 @@ workflows:
           filters: 'pipeline.parameters.ruby and pipeline.git.branch != "master"'
       - ruby-push-amd64:
           context: docker
-          filters: 'pipeline.parameters.ruby and pipeline.git.branch == "master"'
+          filters: 'pipeline.parameters.ruby_publish and pipeline.git.branch == "master"'
       - ruby-push-arm64:
           context: docker
-          filters: 'pipeline.parameters.ruby and pipeline.git.branch == "master"'
+          filters: 'pipeline.parameters.ruby_publish and pipeline.git.branch == "master"'
       - ruby-manifest:
           context: docker
           requires:
             - ruby-push-amd64
             - ruby-push-arm64
-          filters: 'pipeline.parameters.ruby and pipeline.git.branch == "master"'
+          filters: 'pipeline.parameters.ruby_publish and pipeline.git.branch == "master"'
       - sync:
           requires:
             - lint

--- a/README.md
+++ b/README.md
@@ -203,9 +203,10 @@ make clean
 CircleCI uses path filtering from `.circleci/config.yml`; the continued config
 defines image build, publish, manifest, sync, and release jobs.
 
-On `master`, CI publishes platform images and manifests with the CircleCI
-`docker` context. On non-`master` branches, CI builds changed images and runs
-`make sync push`.
+On non-`master` branches, CI builds changed images, validates image jobs after
+CircleCI config changes, and runs `make sync push`. On `master`, CI publishes
+platform images and manifests only for images whose version-bearing `Makefile`
+changed, using the CircleCI `docker` context.
 
 Stack-only changes to `compose.yml`, `grafana/`, `otelcol/`, `prometheus/`, or
 `status/` are outside the image path filters, so validate them locally with


### PR DESCRIPTION
## What

- Split CircleCI image validation parameters from master publish parameters.
- Keep branch image builds path-filtered on image, shared build, and CircleCI config changes while limiting master push and manifest jobs to image Makefile changes.
- Update the README CI note to describe branch validation and the version-bearing Makefile publish signal.

## Why

- Avoid republishing immutable DockerHub image tags when a PR changes CI or image files without changing image versions.
- Preserve branch validation coverage for Dockerfile, installer, shared build, and CI orchestration changes without treating every validated change as publish intent.

## Testing

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .circleci/config.yml .circleci/continue_config.yml` - passed
- `make lint` - passed
- `git diff --check` - passed
- `circleci config validate .circleci/config.yml` - passed
- `circleci config validate .circleci/continue_config.yml` - passed
- local path-filtering mapping simulation for representative file changes - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
