### PR TITLE
feat(root): install libsodium for rbnacl-backed paseto tokens

### DIFF
--- a/root/Dockerfile
+++ b/root/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   libncurses-dev \
   libpq-dev \
   libreadline-dev \
+  libsodium-dev \
   libssh2-1t64 \
   libssl-dev \
   libyaml-dev \

--- a/root/Makefile
+++ b/root/Makefile
@@ -1,5 +1,5 @@
 IMAGE:=root
-VERSION:=3.11
+VERSION:=3.12
 
 include ../bin/build/make/help.mak
 include ../make/docker.mk


### PR DESCRIPTION
## What

- Add `libsodium-dev` to the base image's apt packages so `rbnacl` has the system libsodium library it loads at runtime.
- Bump `root/Makefile` `VERSION` 3.11 → 3.12 (minor).

## Why

- nonnative's new PASETO v4.public token generation uses `rbnacl`, which dlopens system libsodium at runtime. The base image did not ship it, so PASETO would fail in CI and tooling built on this image. This provisions libsodium at the base layer.
- Stage 1 of the two-stage `root/` update (per `AGENTS.md`): dependent images (for example `ruby`) and downstream consumers are bumped separately once this root image publishes.

## Testing

- `make lint` - passed (hadolint on all Dockerfiles including `root/`, shellcheck clean)
- Image build intentionally deferred to CI's non-master build+scan; `libsodium-dev` is a standard Debian trixie package.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
