### PR TITLE
feat(deps): adopt root 3.12 with libsodium across dependent images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.11
+FROM alexfalkowski/root:3.12
 
 USER root
 WORKDIR /usr/local/bin

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,5 +1,5 @@
 IMAGE:=docker
-VERSION:=3.17
+VERSION:=3.18
 
 include ../bin/build/make/help.mak
 include ../make/docker.mk

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.11
+FROM alexfalkowski/root:3.12
 
 USER root
 WORKDIR /usr/local/bin

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,5 +1,5 @@
 IMAGE:=go
-VERSION:=4.23
+VERSION:=4.24
 
 include ../bin/build/make/help.mak
 include ../make/docker.mk

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.11
+FROM alexfalkowski/root:3.12
 
 USER root
 WORKDIR /usr/local/bin

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1,5 +1,5 @@
 IMAGE:=k8s
-VERSION:=4.36
+VERSION:=4.37
 
 include ../bin/build/make/help.mak
 include ../make/docker.mk

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.11
+FROM alexfalkowski/root:3.12
 
 USER root
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,5 +1,5 @@
 IMAGE:=release
-VERSION:=8.21
+VERSION:=8.22
 
 include ../bin/build/make/help.mak
 include ../make/docker.mk

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexfalkowski/root:3.11
+FROM alexfalkowski/root:3.12
 
 USER root
 WORKDIR /usr/local/bin

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -1,5 +1,5 @@
 IMAGE:=ruby
-VERSION:=3.19
+VERSION:=3.20
 
 include ../bin/build/make/help.mak
 include ../make/docker.mk


### PR DESCRIPTION
## What

- Point the five images that build on `alexfalkowski/root` at the new base: `FROM alexfalkowski/root:3.12`, for `docker`, `go`, `ruby`, `release`, and `k8s`.
- Minor-bump each image `VERSION`: `docker` 3.17 → 3.18, `go` 4.23 → 4.24, `ruby` 3.19 → 3.20, `release` 8.21 → 8.22, `k8s` 4.36 → 4.37.

## Why

- Stage 1 added `libsodium-dev` to the `root` base image (published as `3.12`) so `rbnacl` — used by nonnative's PASETO v4.public token generation — has the system libsodium library it loads at runtime. This is Stage 2 of the repo's two-stage `root/` process: dependents adopt the new root in a separate change.
- The `ruby` image is the one nonnative's CI consumes, so this rollout is what actually delivers libsodium to that pipeline. Per `AGENTS.md`, root's minor bump means each dependent gets a minor bump.

## Testing

- `make lint` - passed (hadolint on all Dockerfiles, shellcheck on all scripts)
- Image builds and scans are intentionally deferred to CI's non-master `test-docker`; the changes are `FROM`-tag and `VERSION` bumps only.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
