### PR TITLE
build(deps): wire codex discovery

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../bin/skills

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 include bin/build/make/help.mak
 include bin/build/make/git.mak
 include bin/build/make/claude.mak
+include bin/build/make/codex.mak
 
 # Lint all scripts.
 lint:


### PR DESCRIPTION
## What

- Update the shared `bin` submodule to the merged Codex skill discovery wiring.
- Include `bin/build/make/codex.mak` in the repository Makefile.
- Add `.agents/skills` as a repo-local symlink to `bin/skills` for `$skill` discovery.

## Why

- Codex discovers repository skills through `.agents/skills`, while Claude Code uses `.claude/skills`.
- Committing the repo-local symlink lets future Codex sessions invoke shared skills directly after the submodule update.
- The updated shared `source-key` helper excludes agent wiring symlinks so cache-key generation does not try to hash `.agents/skills` as a directory.

## Testing

- `make codex-init` - passed
- `make help` - passed
- `make source-key` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
