### PR TITLE
feat(codecov): repoint cli install at renamed release repository

### DIFF
--- a/scripts/install-image-tool.d/codecov
+++ b/scripts/install-image-tool.d/codecov
@@ -9,8 +9,8 @@ case "$(uname -m)" in
   *) unsupported_arch "$(uname -m)" ;;
 esac
 
-base_url="https://github.com/getsentry/prevent-cli/releases/download/${tag}"
+base_url="https://github.com/codecov/codecov-cli/releases/download/${tag}"
 
 download "$base_url/$asset" "$asset"
-verify_github_asset_digest getsentry/prevent-cli "$tag" "$asset"
+verify_github_asset_digest codecov/codecov-cli "$tag" "$asset"
 install_binary "$asset" codecovcli


### PR DESCRIPTION
## What

- Point the shared Codecov CLI installer snippet
  (`scripts/install-image-tool.d/codecov`) at the `codecov/codecov-cli`
  release repository for both the download URL and the GitHub asset digest
  verification, replacing the old `getsentry/prevent-cli` source.
- Source-repository move only: the pinned version (`11.2.8`), the `v`-prefixed
  release tag format, the asset names (`codecovcli_linux`,
  `codecovcli_linux_arm64`), the installed `codecovcli` binary name, and the
  dependent `go`/`ruby` image `VERSION` values are all unchanged.

## Why

- The `getsentry/prevent-cli` release URL no longer serves the assets, so image
  builds running `install-image-tool codecov` would fail to download and verify
  the CLI. `codecov/codecov-cli` publishes the same tagged assets with SHA256
  digests, so the fail-closed `verify_github_asset_digest` behavior is preserved
  while restoring a working download source.

## Testing

- `make lint` - passed (shellcheck + hadolint).
- Manual: downloaded `codecovcli_linux` from the new repo at tag `v11.2.8` and
  confirmed its SHA256 matches the digest returned by the GitHub release API;
  confirmed both `codecovcli_linux` and `codecovcli_linux_arm64` expose digests
  at the new repo.
- Confirmed no remaining `getsentry`/`prevent-cli` references and no docs
  reference the old URL (outside vendored `bin/`).
- CI: path-filtered CircleCI builds and scans the `go` and `ruby` images that
  install this tool as additional verification.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
