### PR TITLE
feat(compose): route tempo metrics-generator remote-write to mimir

### DIFF
--- a/grafana/tempo.yml
+++ b/grafana/tempo.yml
@@ -67,7 +67,7 @@ metrics_generator:
   storage:
     path: /var/tempo/generator/wal
     remote_write:
-      - url: http://prometheus:9090/api/v1/write
+      - url: http://mimir:9009/api/v1/push
         send_exemplars: true
   traces_storage:
     path: /var/tempo/generator/traces


### PR DESCRIPTION
## What

- Point Tempo's metrics-generator `remote_write` at `http://mimir:9009/api/v1/push` (the stack's metrics backend) instead of `http://prometheus:9090/api/v1/write`, in `grafana/tempo.yml`. This is the local `make start` dependency stack only — no image, CI, or published-artifact change.
- This aligns Tempo with the stack's other metrics writers: `otelcol` (`prometheusremotewrite` exporter) and `prometheus` (`remote_write`) already push to `mimir:9009/api/v1/push`. `send_exemplars: true` is unchanged.

## Why

- The `prometheus` service runs without `--web.enable-remote-write-receiver`, so `prometheus:9090/api/v1/write` returns 404. Tempo's generator is active by default (processors `service-graphs, span-metrics, local-blocks`, empty per-tenant overrides), so it was silently failing every remote-write — losing all generated span-metrics and service-graph data and logging continuous errors. Mimir accepts Prometheus remote-write on `/api/v1/push` by default and, with `multitenancy_enabled: false`, needs no tenant header, so routing there fixes ingestion without enabling a second, inconsistent path on Prometheus.

## Testing

- `make stack-config` - passed
- `make lint` - passed
- `grafana/tempo.yml` re-parsed as valid YAML, and a repo-wide grep confirms no remaining references to the old `prometheus:9090/api/v1/write` endpoint. An independent review confirmed Tempo now targets the identical endpoint the two already-working writers use.
- Runtime confirmation not run: verifying Tempo logs are error-free and that metrics land in Mimir requires `make start` (docker daemon plus image pulls), which was out of scope. No repository CI target exercises the running stack; the CI `stack` job runs `make stack-config`, which passed.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
